### PR TITLE
Add Railway Sandboxes provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img alt="Sandbox SDK with supported provider logos" src="./Background-with-text.png" width="820" />
 </p>
 
-Run the same TypeScript sandbox code on Local, E2B, Daytona, Vercel Sandbox, or Upstash Box.
+Run the same TypeScript sandbox code on Local, E2B, Daytona, Vercel Sandbox, Upstash Box, or Railway.
 
 ## Install
 
@@ -35,6 +35,7 @@ Node.js 24 and Bun run this syntax directly. On Node.js 22, compile TypeScript t
 | [Daytona](https://sandbox-sdk.app/docs/providers/daytona)       | Cloud workspace         | Persistent projects and GPUs            |
 | [Vercel Sandbox](https://sandbox-sdk.app/docs/providers/vercel) | Hosted Linux sandbox    | Coding agents and persistent workspaces |
 | [Upstash Box](https://sandbox-sdk.app/docs/providers/upstash)   | Durable cloud container | Serverless agents and long-lived state  |
+| [Railway](https://sandbox-sdk.app/docs/providers/railway)       | Ephemeral Linux VM      | Isolated jobs, forks, and templates     |
 
 Local is included. Cloud providers use their official SDKs and credentials.
 

--- a/apps/fumadocs/content/docs/api/ports.mdx
+++ b/apps/fumadocs/content/docs/api/ports.mdx
@@ -27,5 +27,6 @@ Authenticated adapters keep preview credentials inside `request()`. `toJSON()` n
 | Daytona        | Returns a public or token-authenticated preview URL.               |
 | Vercel Sandbox | Registers the port and returns a public `vercel.run` route.        |
 | Upstash Box    | Returns a public URL or keeps its bearer token inside `request()`. |
+| Railway        | Normalized expose is unsupported; use CLI forward or `sandbox.raw`. |
 
 Compare provider preview behavior in [Providers](/docs/providers).

--- a/apps/fumadocs/content/docs/api/sandboxes.mdx
+++ b/apps/fumadocs/content/docs/api/sandboxes.mdx
@@ -43,7 +43,7 @@ Node.js 24 and Bun run `await using` directly. TypeScript 5.2 or newer can compi
 | Property       | Type                 | Description                                         |
 | -------------- | -------------------- | --------------------------------------------------- |
 | `id`           | `string`             | Provider or adapter identifier for this sandbox.    |
-| `provider`     | `ProviderName`       | `local`, `e2b`, `daytona`, `vercel`, or `upstash`.  |
+| `provider`     | `ProviderName`       | `local`, `e2b`, `daytona`, `vercel`, `upstash`, or `railway`. |
 | `cwd`          | `string`             | Normalized working directory.                       |
 | `capabilities` | `CapabilityMap`      | Supported operations and their modes.               |
 | `raw`          | Provider-native type | Typed access to the underlying provider SDK object. |

--- a/apps/fumadocs/content/docs/index.mdx
+++ b/apps/fumadocs/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: Quickstart
 description: Install Sandbox SDK, run a Local sandbox, and switch to a cloud provider.
 ---
 
-Sandbox SDK uses one TypeScript API for Local, E2B, Daytona, Vercel Sandbox, and Upstash Box.
+Sandbox SDK uses one TypeScript API for Local, E2B, Daytona, Vercel Sandbox, Upstash Box, and Railway.
 
 ## Install
 

--- a/apps/fumadocs/content/docs/integrations/eve.mdx
+++ b/apps/fumadocs/content/docs/integrations/eve.mdx
@@ -40,7 +40,7 @@ Eve runs `bootstrap` once for a template identity. Each durable session starts f
 
 ## Choose a provider
 
-<Tabs items={["Local", "E2B", "Daytona", "Vercel", "Upstash"]}>
+<Tabs items={["Local", "E2B", "Daytona", "Vercel", "Upstash", "Railway"]}>
   <Tab value="Local">
     ```ts
     import { local } from "@opencoredev/sandbox-sdk/local";
@@ -71,6 +71,13 @@ Eve runs `bootstrap` once for a template identity. Each durable session starts f
     import { upstash } from "@opencoredev/sandbox-sdk/upstash";
     const backend = createEveSandboxBackend({ provider: upstash({ runtime: "node" }) });
     ```
+  </Tab>
+  <Tab value="Railway">
+    ```ts
+    import { railway } from "@opencoredev/sandbox-sdk/railway";
+    const backend = createEveSandboxBackend({ provider: railway() });
+    ```
+    Set `RAILWAY_API_TOKEN` and `RAILWAY_ENVIRONMENT_ID`.
   </Tab>
 </Tabs>
 

--- a/apps/fumadocs/content/docs/integrations/mastra.mdx
+++ b/apps/fumadocs/content/docs/integrations/mastra.mdx
@@ -25,6 +25,7 @@ The Local provider is included. Install the native SDK only for the cloud provid
 | Daytona        | `@daytona/sdk`     |
 | Vercel Sandbox | `@vercel/sandbox`  |
 | Upstash Box    | `@upstash/box`     |
+| Railway        | `railway`          |
 
 Configure the provider's credentials as described in its [provider guide](/docs/providers). The agent example below also expects `OPENAI_API_KEY` for its selected model.
 
@@ -76,7 +77,7 @@ The adapter normalizes Mastra's workspace contract once. Switching providers cha
 
 Every supported provider uses the same `createMastraWorkspace()` factory.
 
-<Tabs items={["Local", "E2B", "Daytona", "Vercel", "Upstash"]}>
+<Tabs items={["Local", "E2B", "Daytona", "Vercel", "Upstash", "Railway"]}>
   <Tab value="Local">
     ```ts
     import { createMastraWorkspace } from "@opencoredev/sandbox-sdk/mastra";
@@ -138,6 +139,18 @@ Every supported provider uses the same `createMastraWorkspace()` factory.
     });
     ```
     Set `UPSTASH_BOX_API_KEY` before starting the agent.
+
+  </Tab>
+  <Tab value="Railway">
+    ```ts
+    import { createMastraWorkspace } from "@opencoredev/sandbox-sdk/mastra";
+    import { railway } from "@opencoredev/sandbox-sdk/railway";
+
+    export const workspace = createMastraWorkspace({
+      provider: railway(),
+    });
+    ```
+    Set `RAILWAY_API_TOKEN` and `RAILWAY_ENVIRONMENT_ID` before starting the agent.
 
   </Tab>
 </Tabs>

--- a/apps/fumadocs/content/docs/providers/index.mdx
+++ b/apps/fumadocs/content/docs/providers/index.mdx
@@ -13,6 +13,7 @@ Every provider supports files, foreground commands, background processes, stream
 | [Daytona](/docs/providers/daytona)       | <ProviderDocsLink provider="daytona" /> | Persistent workspaces, GPUs          | Linux workspace | Persistent     | Public or authenticated | Native API           |
 | [Vercel Sandbox](/docs/providers/vercel) | <ProviderDocsLink provider="vercel" />  | Coding agents, persistent workspaces | Linux sandbox   | Default on     | Public                  | Filesystem           |
 | [Upstash Box](/docs/providers/upstash)   | <ProviderDocsLink provider="upstash" /> | Durable serverless boxes             | Linux container | Persistent     | Public or bearer token  | Filesystem           |
+| [Railway](/docs/providers/railway)       | <ProviderDocsLink provider="railway" /> | Ephemeral VMs, forks, templates      | Linux VM        | Ephemeral      | CLI forward / raw       | Fork                 |
 
 Optional semantics differ. Check the generated [compatibility matrix](/docs/reference/compatibility) before depending on stdin, restore, resume, networking, GPUs, or a custom image.
 

--- a/apps/fumadocs/content/docs/providers/meta.json
+++ b/apps/fumadocs/content/docs/providers/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Providers",
   "icon": "providers",
-  "pages": ["index", "local", "e2b", "daytona", "vercel", "upstash"]
+  "pages": ["index", "local", "e2b", "daytona", "vercel", "upstash", "railway"]
 }

--- a/apps/fumadocs/content/docs/providers/railway.mdx
+++ b/apps/fumadocs/content/docs/providers/railway.mdx
@@ -1,0 +1,98 @@
+---
+title: Railway Sandboxes
+description: Run Railway hosted Linux sandboxes through the normalized SDK API.
+icon: railway
+---
+
+Railway provides ephemeral Linux sandboxes (VMs) with files, commands, templates, forks, and checkpoints. See the [Railway sandboxes docs](https://docs.railway.com/sandboxes).
+
+Sandboxes are available through Railway Priority Boarding and the official `railway` TypeScript SDK may change while the feature is in preview.
+
+## Installation
+
+```bash title="Terminal"
+bun add @opencoredev/sandbox-sdk railway
+```
+
+## Authentication
+
+Set `RAILWAY_API_TOKEN` and `RAILWAY_ENVIRONMENT_ID`, or pass them to `railway()`:
+
+```ts title="credentials.ts"
+import { railway } from "@opencoredev/sandbox-sdk/railway";
+
+const provider = railway({
+  token: process.env.RAILWAY_API_TOKEN!,
+  environmentId: process.env.RAILWAY_ENVIRONMENT_ID!,
+});
+```
+
+Create an API token in the Railway dashboard and use an environment from a Railway project. Each sandbox is scoped to that environment.
+
+## Run a command
+
+```ts title="railway.ts"
+import { createSandbox } from "@opencoredev/sandbox-sdk";
+import { railway } from "@opencoredev/sandbox-sdk/railway";
+
+await using sandbox = await createSandbox({ provider: railway() });
+const result = await sandbox.run("node --version");
+console.log(result.stdout);
+```
+
+## Run an agent
+
+Export one provider instance and pass it to [AI SDK](/docs/integrations/ai-sdk), [HarnessAgent](/docs/integrations/ai-sdk-harness), [Eve](/docs/integrations/eve), or [Mastra](/docs/integrations/mastra).
+
+```ts title="agent-provider.ts"
+import { railway } from "@opencoredev/sandbox-sdk/railway";
+
+export const agentSandboxProvider = railway();
+```
+
+## Files and processes
+
+```ts title="workspace.ts"
+await sandbox.files.write("index.mjs", `console.log("ready")`);
+const process = await sandbox.processes.start("node index.mjs");
+
+for await (const event of process.output()) {
+  console.log(event.stream, event.data);
+}
+```
+
+Railway supports background processes, cancellation via `process.kill()`, and separate stdout and stderr streams. Normalized stdin is not available. Long-running sessions can be detached and reattached through `sandbox.raw`.
+
+## Ports and snapshots
+
+Normalized `ports.expose()` is not supported. Forward ports with the Railway CLI (`railway sandbox forward`) or use `sandbox.raw`.
+
+`snapshots.create()` forks the running sandbox's filesystem into a new independent sandbox. Deleting a snapshot destroys that fork. Named checkpoints and template builds remain available on `sandbox.raw`.
+
+```ts title="snapshot.ts"
+const snapshot = await sandbox.snapshots.create({ name: "prepared" });
+await sandbox.snapshots.delete(snapshot);
+```
+
+## Options
+
+| Option                | Type                     | Default                    | Behavior                                                         |
+| --------------------- | ------------------------ | -------------------------- | ---------------------------------------------------------------- |
+| `token`               | `string`                 | `RAILWAY_API_TOKEN`        | Authenticates Railway API requests.                              |
+| `environmentId`       | `string`                 | `RAILWAY_ENVIRONMENT_ID`   | Scopes sandboxes to a Railway environment.                       |
+| `idleTimeoutMinutes`  | `number`                 | Plan default               | Auto-destroys idle sandboxes. Max depends on plan.               |
+| `networkIsolation`    | `ISOLATED` \| `PRIVATE`  | `ISOLATED`                 | `PRIVATE` joins the environment private network.                 |
+
+Creation also maps `createSandbox({ timeout })` to `idleTimeoutMinutes` when the adapter option is unset.
+
+## Behavior
+
+- Sandboxes start from a clean Debian base once `Sandbox.create()` resolves.
+- Files are ephemeral unless you fork, checkpoint, or build a template through `sandbox.raw`.
+- Managed sessions keep the live sandbox reference in the current process.
+- Templates, checkpoints, SSH, and network isolation remain available through `sandbox.raw`.
+- Destroy sandboxes when done; idle sandboxes still consume billable resources.
+
+## Read next
+
+Compare exact modes in [Compatibility](/docs/reference/compatibility), or connect Railway to [HarnessAgent](/docs/integrations/ai-sdk-harness). Official reference: [docs.railway.com/sandboxes](https://docs.railway.com/sandboxes).

--- a/apps/fumadocs/content/docs/reference/compatibility.mdx
+++ b/apps/fumadocs/content/docs/reference/compatibility.mdx
@@ -16,6 +16,7 @@ The matrix is generated from the same capability declarations exported by the ad
 - Vercel and E2B snapshots create provider-native artifacts, but restore creates a new native sandbox and stays on `raw`.
 - Daytona persistence, PTYs, networking, images, and GPUs are provider-native capabilities beyond the normalized core.
 - Upstash Box provides durable filesystems, pause and resume, network policies, and public or bearer-token URLs; snapshot restore creates a new native Box.
+- Railway sandboxes are ephemeral VMs with fork-based snapshots; templates, checkpoints, and SSH remain on `sandbox.raw`. Normalized port expose is unsupported.
 
 ## Read next
 

--- a/apps/fumadocs/content/docs/reference/package-exports.mdx
+++ b/apps/fumadocs/content/docs/reference/package-exports.mdx
@@ -19,6 +19,7 @@ import { e2b } from "@opencoredev/sandbox-sdk/e2b";
 import { daytona } from "@opencoredev/sandbox-sdk/daytona";
 import { vercel } from "@opencoredev/sandbox-sdk/vercel";
 import { upstash } from "@opencoredev/sandbox-sdk/upstash";
+import { railway } from "@opencoredev/sandbox-sdk/railway";
 ```
 
 Each adapter export includes its options type, native sandbox type, and capability declaration.

--- a/apps/fumadocs/src/app/(home)/partners/page.tsx
+++ b/apps/fumadocs/src/app/(home)/partners/page.tsx
@@ -28,7 +28,8 @@ export default function PartnersPage() {
       <article className="prose mt-12 max-w-3xl">
         <h2>What we maintain</h2>
         <p>
-          OpenCore maintains five integrations: Local, E2B, Daytona, Vercel Sandbox and Upstash Box.
+          OpenCore maintains integrations for Local, E2B, Daytona, Vercel Sandbox, Upstash Box, and
+          Railway.
           Local is powered by AgentOS under the hood. The unified API covers files, commands,
           processes, ports, capabilities, errors, cleanup and typed native access.
         </p>

--- a/apps/fumadocs/src/app/layout.tsx
+++ b/apps/fumadocs/src/app/layout.tsx
@@ -47,6 +47,7 @@ export const metadata: Metadata = {
     "Daytona",
     "Vercel Sandbox",
     "Upstash Box",
+    "Railway Sandboxes",
   ],
   alternates: { canonical: "/" },
   openGraph: {

--- a/apps/fumadocs/src/components/docs-icon.tsx
+++ b/apps/fumadocs/src/components/docs-icon.tsx
@@ -27,6 +27,8 @@ export function ProviderLogo({ id, ...props }: IconProps & { id: string }) {
       return <VercelLogo {...props} />;
     case "upstash":
       return <UpstashLogo {...props} />;
+    case "railway":
+      return <RailwayLogo {...props} />;
     default:
       return <HugeiconsIcon icon={ServerStack01Icon} className={props.className} />;
   }
@@ -42,6 +44,7 @@ export function resolveDocsIcon(icon: string | undefined): ReactNode {
     case "daytona":
     case "vercel":
     case "upstash":
+    case "railway":
       return <ProviderLogo id={icon} />;
     case "integrations":
       return <HugeiconsIcon icon={PlugSocketIcon} />;
@@ -96,6 +99,17 @@ function UpstashLogo(props: IconProps) {
       <path
         fill="currentColor"
         d="M13.803 0c-2.61 0-5.22.995-7.211 2.986-3.982 3.983-3.982 10.44 0 14.422a5.1 5.1 0 0 0 7.21-7.21L12 12a2.55 2.55 0 0 1-3.605 3.605A7.649 7.649 0 0 1 19.21 4.79l1.803-1.803A10.17 10.17 0 0 0 13.803 0M12 12a2.55 2.55 0 0 1 3.605-3.605A7.649 7.649 0 0 1 4.79 19.21l-1.803 1.803c3.983 3.982 10.44 3.982 14.422 0s3.982-10.44 0-14.422A5.08 5.08 0 0 0 13.803 5.1a5.1 5.1 0 0 0-3.605 8.703z"
+      />
+    </svg>
+  );
+}
+
+function RailwayLogo(props: IconProps) {
+  return (
+    <svg {...iconProps} {...props} viewBox="0 0 24 24">
+      <path
+        fill="currentColor"
+        d="M4 2h16a2 2 0 0 1 2 2v16a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2m1.5 3v5.25L12 16.5l6.5-6.25V5z"
       />
     </svg>
   );

--- a/bun.lock
+++ b/bun.lock
@@ -68,6 +68,7 @@
         "ai": "^7",
         "e2b": "^2.32.0",
         "eve": "^0.22",
+        "railway": "^3.5.7",
         "tsdown": "^0.16.6",
         "typescript": "^6.0.3",
       },
@@ -80,6 +81,7 @@
         "ai": "^7.0.0",
         "e2b": "^2.32.0",
         "eve": "^0.22.0",
+        "railway": "^3.5.7",
       },
       "optionalPeers": [
         "@ai-sdk/harness",
@@ -90,6 +92,7 @@
         "ai",
         "e2b",
         "eve",
+        "railway",
       ],
     },
   },
@@ -307,6 +310,8 @@
     "@fumadocs/tailwind": ["@fumadocs/tailwind@0.1.1", "", { "peerDependencies": { "tailwindcss": "^4.0.0" }, "optionalPeers": ["tailwindcss"] }, "sha512-BnPe52UxSaG8yKlHMKBxXw8h6GpK5qO55ci6+Qd5JnquTvIw6SpfbC1P+qAi82PuPWv1KZAWY8bxRk4+x9ctXw=="],
 
     "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
+
+    "@graphql-typed-document-node/core": ["@graphql-typed-document-node/core@3.2.0", "", { "peerDependencies": { "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ=="],
 
     "@grpc/grpc-js": ["@grpc/grpc-js@1.14.4", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ=="],
 
@@ -1188,6 +1193,8 @@
 
     "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
 
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
     "fumadocs": ["fumadocs@workspace:apps/fumadocs"],
 
     "fumadocs-core": ["fumadocs-core@16.11.3", "", { "dependencies": { "@orama/orama": "^3.1.18", "estree-util-value-to-estree": "^3.5.0", "github-slugger": "^2.0.0", "hast-util-to-estree": "^3.1.3", "hast-util-to-jsx-runtime": "^2.3.6", "js-yaml": "^5.2.1", "mdast-util-mdx": "^3.0.0", "mdast-util-to-markdown": "^2.1.2", "remark": "^15.0.1", "remark-gfm": "^4.0.1", "remark-rehype": "^11.1.2", "scroll-into-view-if-needed": "^3.1.0", "shiki": "^4.3.1", "tinyglobby": "^0.2.17", "unified": "^11.0.5", "unist-util-visit": "^5.1.0", "vfile": "^6.0.3" }, "peerDependencies": { "@mdx-js/mdx": "*", "@mixedbread/sdk": "0.x.x", "@orama/core": "1.x.x", "@oramacloud/client": "2.x.x", "@tanstack/react-router": "1.x.x", "@types/estree-jsx": "*", "@types/hast": "*", "@types/mdast": "*", "@types/react": "*", "algoliasearch": "5.x.x", "flexsearch": "*", "lucide-react": "*", "next": "16.x.x", "react": "^19.2.0", "react-dom": "^19.2.0", "react-router": "7.x.x || 8.x.x", "waku": "*", "zod": "4.x.x" }, "optionalPeers": ["@mdx-js/mdx", "@mixedbread/sdk", "@orama/core", "@oramacloud/client", "@tanstack/react-router", "@types/estree-jsx", "@types/hast", "@types/mdast", "@types/react", "algoliasearch", "flexsearch", "lucide-react", "next", "react", "react-dom", "react-router", "waku", "zod"] }, "sha512-AHhOYY2YA98vEbgzLBxqZ9yyfW6VmOTIIjK803xCOWUmqyiVU8ONckI6IuIEIWTwyvk4s/PAC49p01J0Cjio+w=="],
@@ -1237,6 +1244,8 @@
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "graphql": ["graphql@16.14.2", "", {}, "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA=="],
 
     "gray-matter": ["gray-matter@4.0.3", "", { "dependencies": { "js-yaml": "^3.13.1", "kind-of": "^6.0.2", "section-matter": "^1.0.0", "strip-bom-string": "^1.0.0" } }, "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q=="],
 
@@ -1712,6 +1721,8 @@
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
+    "railway": ["railway@3.5.7", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.2.0", "graphql": "^16.10.0", "tsx": "^4.20.0" }, "bin": { "railway-iac-ts": "dist/iac/bin.js" } }, "sha512-2DdaAw2eSQuCtSn+/VuPNOdnbynxTVmRIQlefhc0maULZTr16Uy/5/FjumnI1lONZgflKG/WMGm9QmUdnApZFw=="],
+
     "range-parser": ["range-parser@1.2.0", "", {}, "sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A=="],
 
     "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
@@ -1935,6 +1946,8 @@
     "tsdown": ["tsdown@0.16.8", "", { "dependencies": { "ansis": "^4.2.0", "cac": "^6.7.14", "chokidar": "^5.0.0", "diff": "^8.0.2", "empathic": "^2.0.0", "hookable": "^5.5.3", "obug": "^2.1.1", "rolldown": "1.0.0-beta.52", "rolldown-plugin-dts": "^0.18.1", "semver": "^7.7.3", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tree-kill": "^1.2.2", "unconfig-core": "^7.4.1", "unrun": "^0.2.13" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@vitejs/devtools": "^0.0.0-alpha.18", "publint": "^0.3.0", "typescript": "^5.0.0", "unplugin-lightningcss": "^0.4.0", "unplugin-unused": "^0.5.0" }, "optionalPeers": ["@arethetypeswrong/core", "@vitejs/devtools", "publint", "typescript", "unplugin-lightningcss", "unplugin-unused"], "bin": { "tsdown": "dist/run.mjs" } }, "sha512-6ANw9mgU9kk7SvTBKvpDu/DVJeAFECiLUSeL5M7f5Nm5H97E7ybxmXT4PQ23FySYn32y6OzjoAH/lsWCbGzfLA=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tsx": ["tsx@4.23.1", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ=="],
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add experimental Railway Sandboxes provider (`@opencoredev/sandbox-sdk/railway`) via the official `railway` SDK.
+
 ## @opencoredev/sandbox-sdk@0.1.1
 
 - Add `Symbol.asyncDispose` to `Sandbox` so `await using` provides automatic cleanup.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -2,7 +2,7 @@
   <img alt="Sandbox SDK with supported provider logos" src="https://raw.githubusercontent.com/opencoredev/sandbox-sdk/main/Background-with-text.png" width="820" />
 </p>
 
-Run the same TypeScript sandbox code on Local, E2B, Daytona, Vercel Sandbox, or Upstash Box.
+Run the same TypeScript sandbox code on Local, E2B, Daytona, Vercel Sandbox, Upstash Box, or Railway.
 
 ## Install
 
@@ -35,6 +35,7 @@ Node.js 24 and Bun run this syntax directly. On Node.js 22, compile TypeScript t
 | [Daytona](https://sandbox-sdk.app/docs/providers/daytona)       | Cloud workspace         | Persistent projects and GPUs            |
 | [Vercel Sandbox](https://sandbox-sdk.app/docs/providers/vercel) | Hosted Linux sandbox    | Coding agents and persistent workspaces |
 | [Upstash Box](https://sandbox-sdk.app/docs/providers/upstash)   | Durable cloud container | Serverless agents and long-lived state  |
+| [Railway](https://sandbox-sdk.app/docs/providers/railway)       | Ephemeral Linux VM      | Isolated jobs, forks, and templates     |
 
 Local is included. Cloud providers use their official SDKs and credentials.
 

--- a/packages/sdk/examples/railway.ts
+++ b/packages/sdk/examples/railway.ts
@@ -1,0 +1,5 @@
+import { createSandbox } from "../src";
+import { railway } from "../src/providers/railway";
+
+await using sandbox = await createSandbox({ provider: railway() });
+console.log((await sandbox.run("printf railway")).stdout);

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -46,6 +46,10 @@
       "types": "./dist/providers/upstash/index.d.mts",
       "import": "./dist/providers/upstash/index.mjs"
     },
+    "./railway": {
+      "types": "./dist/providers/railway/index.d.mts",
+      "import": "./dist/providers/railway/index.mjs"
+    },
     "./metadata": {
       "types": "./dist/metadata.d.mts",
       "import": "./dist/metadata.mjs"
@@ -106,6 +110,7 @@
     "ai": "^7",
     "e2b": "^2.32.0",
     "eve": "^0.22",
+    "railway": "^3.5.7",
     "tsdown": "^0.16.6",
     "typescript": "^6.0.3"
   },
@@ -117,7 +122,8 @@
     "@vercel/sandbox": "^2.5.0",
     "ai": "^7.0.0",
     "e2b": "^2.32.0",
-    "eve": "^0.22.0"
+    "eve": "^0.22.0",
+    "railway": "^3.5.7"
   },
   "peerDependenciesMeta": {
     "e2b": {
@@ -142,6 +148,9 @@
       "optional": true
     },
     "eve": {
+      "optional": true
+    },
+    "railway": {
       "optional": true
     }
   },

--- a/packages/sdk/src/core/types.ts
+++ b/packages/sdk/src/core/types.ts
@@ -1,4 +1,4 @@
-export const providerNames = ["local", "e2b", "daytona", "vercel", "upstash"] as const;
+export const providerNames = ["local", "e2b", "daytona", "vercel", "upstash", "railway"] as const;
 export type ProviderName = (typeof providerNames)[number];
 
 export const capabilityNames = [

--- a/packages/sdk/src/metadata.ts
+++ b/packages/sdk/src/metadata.ts
@@ -2,6 +2,7 @@ import {
   daytonaCapabilities,
   e2bCapabilities,
   localCapabilities,
+  railwayCapabilities,
   upstashCapabilities,
   vercelCapabilities,
 } from "./providers/capabilities";
@@ -133,6 +134,25 @@ export const providers: readonly ProviderMetadata[] = [
       "Captures persistent workspace state. Restoring creates a new Box and remains available through raw.",
     runtimeLimitations:
       "Durable Debian or Alpine boxes with Node.js, Python, Go, Ruby, or Rust runtimes.",
+  },
+  {
+    id: "railway",
+    displayName: "Railway Sandboxes",
+    officialUrl: "https://docs.railway.com/sandboxes",
+    packageName: "railway",
+    packageVersion: "3.5.7",
+    capabilities: railwayCapabilities,
+    environmentVariables: ["RAILWAY_API_TOKEN", "RAILWAY_ENVIRONMENT_ID"],
+    technicalStatus: "experimental",
+    providerReviewed: false,
+    sponsor: false,
+    liveTest: null,
+    portBehavior:
+      "Normalized ports.expose() is unsupported. Use railway sandbox forward or sandbox.raw for port access.",
+    snapshotBehavior:
+      "snapshot.create() forks the live filesystem into a new sandbox. Restore is unsupported; boot forks or checkpoints through sandbox.raw.",
+    runtimeLimitations:
+      "Priority Boarding feature. Requires a Railway project environment and API token. Sandboxes are ephemeral VMs billed by resource usage.",
   },
 ];
 

--- a/packages/sdk/src/providers/capabilities.ts
+++ b/packages/sdk/src/providers/capabilities.ts
@@ -80,6 +80,22 @@ export const vercelCapabilities = defineCapabilities({
   "network.policy": "native",
 });
 
+export const railwayCapabilities = defineCapabilities({
+  "files.read": "full",
+  "files.write": "full",
+  "files.list": "full",
+  "files.remove": "full",
+  "process.run": "separate-streams",
+  "process.stream": "separate-streams",
+  "process.background": "full",
+  "process.cancel": "full",
+  "snapshot.create": "fork",
+  "snapshot.delete": "fork",
+  "filesystem.persistent": "ephemeral",
+  "image.custom": "template",
+  "network.policy": "native",
+});
+
 export const upstashCapabilities = defineCapabilities({
   "files.read": "full",
   "files.write": "full",

--- a/packages/sdk/src/providers/railway/index.ts
+++ b/packages/sdk/src/providers/railway/index.ts
@@ -118,7 +118,7 @@ export function railway(options: RailwayOptions = {}): SandboxProvider<RailwaySa
             void completed.then(finish, finish);
             const abort = () => {
               void handle.kill();
-              running = false;
+              finish();
             };
             runOptions.signal?.addEventListener("abort", abort, { once: true });
             void completed.finally(() => runOptions.signal?.removeEventListener("abort", abort));
@@ -141,7 +141,7 @@ export function railway(options: RailwayOptions = {}): SandboxProvider<RailwaySa
               wait: () => completed,
               async kill() {
                 await handle.kill();
-                running = false;
+                finish();
               },
             };
             return process;

--- a/packages/sdk/src/providers/railway/index.ts
+++ b/packages/sdk/src/providers/railway/index.ts
@@ -1,5 +1,5 @@
 import { Sandbox as RailwaySandbox } from "railway";
-import { normalizeError } from "../../core/errors";
+import { normalizeError, SandboxError } from "../../core/errors";
 import type { SandboxProvider } from "../../core/provider";
 import type { ProcessOutputEvent, SandboxProcess, SandboxSnapshot } from "../../core/types";
 import { commandString, toUint8Array, unsupported } from "../../internal/provider-utils";
@@ -69,11 +69,15 @@ export function railway(options: RailwayOptions = {}): SandboxProvider<RailwaySa
           },
           async run(command, runOptions) {
             try {
+              assertNotAborted(runOptions.signal, "process.run");
               const started = performance.now();
-              const result = await raw.exec(commandString(command), {
+              const handle = raw.exec(commandString(command), {
                 cwd: runOptions.cwd,
                 env: runOptions.env ? { ...runOptions.env } : undefined,
                 timeoutSec: runOptions.timeout ? Math.ceil(runOptions.timeout / 1_000) : undefined,
+              });
+              const result = await withAbort(handle, runOptions.signal, async () => {
+                await handle.kill();
               });
               return {
                 stdout: result.stdout,
@@ -87,6 +91,7 @@ export function railway(options: RailwayOptions = {}): SandboxProvider<RailwaySa
             }
           },
           async start(command, runOptions) {
+            assertNotAborted(runOptions.signal, "process.start");
             const events: ProcessOutputEvent[] = [];
             const waiters = new Set<() => void>();
             let running = true;
@@ -111,6 +116,12 @@ export function railway(options: RailwayOptions = {}): SandboxProvider<RailwaySa
               waiters.clear();
             };
             void completed.then(finish, finish);
+            const abort = () => {
+              void handle.kill();
+              running = false;
+            };
+            runOptions.signal?.addEventListener("abort", abort, { once: true });
+            void completed.finally(() => runOptions.signal?.removeEventListener("abort", abort));
             const process: SandboxProcess = {
               id: await handle.sessionName,
               async status() {
@@ -175,3 +186,44 @@ export function railway(options: RailwayOptions = {}): SandboxProvider<RailwaySa
 }
 
 export type { RailwaySandbox };
+
+function assertNotAborted(signal: AbortSignal | undefined, operation: string): void {
+  if (signal?.aborted) throw interrupted(operation);
+}
+
+function interrupted(operation: string): SandboxError {
+  return new SandboxError({
+    code: "terminated",
+    provider: "railway",
+    operation,
+    message: "Operation was aborted",
+  });
+}
+
+async function withAbort<T>(
+  work: PromiseLike<T>,
+  signal: AbortSignal | undefined,
+  onAbort: () => void | Promise<void>,
+): Promise<T> {
+  if (!signal) return await work;
+  if (signal.aborted) {
+    await onAbort();
+    throw interrupted("process.run");
+  }
+  return await new Promise<T>((resolve, reject) => {
+    const abort = () => {
+      void Promise.resolve(onAbort()).finally(() => reject(interrupted("process.run")));
+    };
+    signal.addEventListener("abort", abort, { once: true });
+    Promise.resolve(work).then(
+      (value) => {
+        signal.removeEventListener("abort", abort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener("abort", abort);
+        reject(error);
+      },
+    );
+  });
+}

--- a/packages/sdk/src/providers/railway/index.ts
+++ b/packages/sdk/src/providers/railway/index.ts
@@ -1,0 +1,177 @@
+import { Sandbox as RailwaySandbox } from "railway";
+import { normalizeError } from "../../core/errors";
+import type { SandboxProvider } from "../../core/provider";
+import type { ProcessOutputEvent, SandboxProcess, SandboxSnapshot } from "../../core/types";
+import { commandString, toUint8Array, unsupported } from "../../internal/provider-utils";
+import { withManagedSessions } from "../../internal/managed-provider";
+import { railwayCapabilities } from "../capabilities";
+
+export interface RailwayOptions {
+  /** Railway API token. Defaults to `RAILWAY_API_TOKEN`. */
+  token?: string;
+  /** Target environment. Defaults to `RAILWAY_ENVIRONMENT_ID`. */
+  environmentId?: string;
+  /** Minutes of idle time before Railway auto-destroys the sandbox. */
+  idleTimeoutMinutes?: number;
+  /** `ISOLATED` (default, egress only) or `PRIVATE` (joins the environment network). */
+  networkIsolation?: "ISOLATED" | "PRIVATE";
+}
+
+export { railwayCapabilities } from "../capabilities";
+
+export function railway(options: RailwayOptions = {}): SandboxProvider<RailwaySandbox> {
+  return withManagedSessions(
+    {
+      id: "railway",
+      capabilities: railwayCapabilities,
+      async create(createOptions) {
+        const idleTimeoutMinutes =
+          options.idleTimeoutMinutes ??
+          (createOptions.timeout ? Math.max(1, Math.ceil(createOptions.timeout / 60_000)) : undefined);
+        const raw = await RailwaySandbox.create({
+          token: options.token,
+          environmentId: options.environmentId,
+          idleTimeoutMinutes,
+          networkIsolation: options.networkIsolation,
+          env: { ...createOptions.env },
+        });
+        try {
+          await raw.files.mkdir(createOptions.cwd);
+        } catch (error) {
+          await raw.destroy().catch(() => undefined);
+          throw error;
+        }
+        return {
+          id: raw.id,
+          raw,
+          capabilities: railwayCapabilities,
+          files: {
+            async write(path, value) {
+              await raw.files.write(path, await toUint8Array(value));
+            },
+            async read(path) {
+              const result = await raw.files.read(path, { format: "bytes" });
+              return result instanceof Uint8Array ? result : new Uint8Array(result);
+            },
+            async list(path) {
+              const entries = await raw.files.list(path);
+              const base = path.replace(/\/$/, "");
+              return entries.map((entry) => ({
+                name: entry.name,
+                path: `${base}/${entry.name}`,
+                type: entry.isDir ? ("directory" as const) : ("file" as const),
+                size: entry.size,
+              }));
+            },
+            mkdir: (path) => raw.files.mkdir(path),
+            remove: (path) => raw.files.remove(path),
+            exists: (path) => raw.files.exists(path),
+          },
+          async run(command, runOptions) {
+            try {
+              const started = performance.now();
+              const result = await raw.exec(commandString(command), {
+                cwd: runOptions.cwd,
+                env: runOptions.env ? { ...runOptions.env } : undefined,
+                timeoutSec: runOptions.timeout ? Math.ceil(runOptions.timeout / 1_000) : undefined,
+              });
+              return {
+                stdout: result.stdout,
+                stderr: result.stderr,
+                exitCode: result.exitCode ?? 1,
+                success: result.exitCode === 0,
+                durationMs: Math.round(performance.now() - started),
+              };
+            } catch (error) {
+              throw normalizeError("railway", "process.run", error);
+            }
+          },
+          async start(command, runOptions) {
+            const events: ProcessOutputEvent[] = [];
+            const waiters = new Set<() => void>();
+            let running = true;
+            const push = (stream: "stdout" | "stderr", data: string) => {
+              events.push({ stream, data, timestamp: new Date() });
+              for (const wake of waiters) wake();
+              waiters.clear();
+            };
+            const handle = raw.exec(commandString(command), {
+              cwd: runOptions.cwd,
+              env: runOptions.env ? { ...runOptions.env } : undefined,
+              timeoutSec: runOptions.timeout ? Math.ceil(runOptions.timeout / 1_000) : undefined,
+              onStdout: (data) => push("stdout", data),
+              onStderr: (data) => push("stderr", data),
+            });
+            const completed = handle.then((result) => ({
+              exitCode: result.exitCode ?? 1,
+            }));
+            const finish = () => {
+              running = false;
+              for (const wake of waiters) wake();
+              waiters.clear();
+            };
+            void completed.then(finish, finish);
+            const process: SandboxProcess = {
+              id: await handle.sessionName,
+              async status() {
+                return running ? "running" : "exited";
+              },
+              async *output() {
+                let index = 0;
+                while (running || index < events.length) {
+                  while (index < events.length) yield events[index++]!;
+                  if (!running) break;
+                  await new Promise<void>((resolve) => waiters.add(resolve));
+                }
+              },
+              async write() {
+                unsupported("railway", "process.stdin");
+              },
+              wait: () => completed,
+              async kill() {
+                await handle.kill();
+                running = false;
+              },
+            };
+            return process;
+          },
+          async expose() {
+            unsupported("railway", "ports.expose");
+          },
+          snapshots: {
+            async create(snapshotOptions) {
+              const fork = await raw.fork();
+              return {
+                id: fork.id,
+                name: snapshotOptions?.name,
+                mode: "fork",
+              } satisfies SandboxSnapshot;
+            },
+            async delete(snapshot) {
+              const id = typeof snapshot === "string" ? snapshot : snapshot.id;
+              const target = await RailwaySandbox.connect(id, {
+                token: options.token,
+                environmentId: options.environmentId,
+              });
+              await target.destroy();
+            },
+            async restore() {
+              unsupported("railway", "snapshot.restore");
+            },
+          },
+          async stop() {
+            await raw.destroy();
+          },
+        };
+      },
+    },
+    [],
+    {
+      destroy: async (sandbox) => {
+        await sandbox.raw.destroy();
+      },
+    },
+  );
+}
+
+export type { RailwaySandbox };

--- a/packages/sdk/tests/providers/railway.test.ts
+++ b/packages/sdk/tests/providers/railway.test.ts
@@ -4,6 +4,7 @@ import { createSandbox } from "../../src";
 const files = new Map<string, Uint8Array>();
 const destroy = mock(async () => {});
 const mkdir = mock(async () => {});
+const kill = mock(async () => {});
 const execResult = {
   stdout: "railway",
   stderr: "",
@@ -11,6 +12,8 @@ const execResult = {
   truncated: false,
   timedOut: false,
 };
+
+let hangExec = false;
 
 class NativeRailway {
   static create = mock(async () => new NativeRailway());
@@ -20,10 +23,16 @@ class NativeRailway {
     return instance;
   });
   id = "railway-test";
-  async exec() {
+  exec() {
+    if (hangExec) {
+      return Object.assign(new Promise(() => {}), {
+        sessionName: Promise.resolve("session-hang"),
+        kill,
+      });
+    }
     return Object.assign(Promise.resolve(execResult), {
       sessionName: Promise.resolve("session-1"),
-      kill: mock(async () => {}),
+      kill,
     });
   }
   files = {
@@ -49,6 +58,7 @@ class NativeRailway {
 mock.module("railway", () => ({ Sandbox: NativeRailway }));
 
 test("Railway adapter maps official SDK operations", async () => {
+  hangExec = false;
   const { railway } = await import("../../src/providers/railway");
   const sandbox = await createSandbox({ provider: railway() });
   expect(NativeRailway.create).toHaveBeenCalled();
@@ -70,4 +80,21 @@ test("Railway adapter maps official SDK operations", async () => {
   await sandbox.stop();
   expect(destroy).toHaveBeenCalled();
   expect(sandbox.raw).toBeInstanceOf(NativeRailway);
+});
+
+test("Railway adapter kills in-flight commands when the abort signal fires", async () => {
+  hangExec = true;
+  kill.mockClear();
+  const { railway } = await import("../../src/providers/railway");
+  const sandbox = await createSandbox({ provider: railway() });
+  const controller = new AbortController();
+  const running = sandbox.run("sleep 30", { signal: controller.signal });
+  controller.abort();
+  await expect(running).rejects.toMatchObject({
+    code: "terminated",
+    provider: "railway",
+    operation: "process.run",
+  });
+  expect(kill).toHaveBeenCalled();
+  await sandbox.stop();
 });

--- a/packages/sdk/tests/providers/railway.test.ts
+++ b/packages/sdk/tests/providers/railway.test.ts
@@ -1,0 +1,73 @@
+import { expect, mock, test } from "bun:test";
+import { createSandbox } from "../../src";
+
+const files = new Map<string, Uint8Array>();
+const destroy = mock(async () => {});
+const mkdir = mock(async () => {});
+const execResult = {
+  stdout: "railway",
+  stderr: "",
+  exitCode: 0,
+  truncated: false,
+  timedOut: false,
+};
+
+class NativeRailway {
+  static create = mock(async () => new NativeRailway());
+  static connect = mock(async (id: string) => {
+    const instance = new NativeRailway();
+    instance.id = id;
+    return instance;
+  });
+  id = "railway-test";
+  async exec() {
+    return Object.assign(Promise.resolve(execResult), {
+      sessionName: Promise.resolve("session-1"),
+      kill: mock(async () => {}),
+    });
+  }
+  files = {
+    write: async (path: string, value: Uint8Array) => {
+      files.set(path, value);
+    },
+    read: async (path: string) => files.get(path)!,
+    list: async () => [],
+    mkdir,
+    remove: async (path: string) => {
+      files.delete(path);
+    },
+    exists: async (path: string) => files.has(path),
+  };
+  fork = mock(async () => {
+    const forked = new NativeRailway();
+    forked.id = "railway-fork";
+    return forked;
+  });
+  destroy = destroy;
+}
+
+mock.module("railway", () => ({ Sandbox: NativeRailway }));
+
+test("Railway adapter maps official SDK operations", async () => {
+  const { railway } = await import("../../src/providers/railway");
+  const sandbox = await createSandbox({ provider: railway() });
+  expect(NativeRailway.create).toHaveBeenCalled();
+  expect(mkdir).toHaveBeenCalled();
+  await sandbox.files.write("file.txt", "value");
+  expect(await sandbox.files.text("file.txt")).toBe("value");
+  expect(await sandbox.run("command")).toMatchObject({ stdout: "railway", success: true });
+  const snapshot = await sandbox.snapshots.create({ name: "forked" });
+  expect(snapshot).toMatchObject({ id: "railway-fork", mode: "fork" });
+  await sandbox.snapshots.delete(snapshot);
+  expect(NativeRailway.connect).toHaveBeenCalledWith(
+    "railway-fork",
+    expect.objectContaining({}),
+  );
+  await expect(sandbox.ports.expose(3000)).rejects.toMatchObject({
+    code: "unsupported",
+    provider: "railway",
+  });
+  await sandbox.stop();
+  expect(destroy).toHaveBeenCalled();
+  expect(sandbox.raw).toBeInstanceOf(NativeRailway);
+});

--- a/packages/sdk/tests/providers/railway.test.ts
+++ b/packages/sdk/tests/providers/railway.test.ts
@@ -98,3 +98,24 @@ test("Railway adapter kills in-flight commands when the abort signal fires", asy
   expect(kill).toHaveBeenCalled();
   await sandbox.stop();
 });
+
+test("Railway process.output() ends after kill without hanging", async () => {
+  hangExec = true;
+  kill.mockClear();
+  const { railway } = await import("../../src/providers/railway");
+  const sandbox = await createSandbox({ provider: railway() });
+  const process = await sandbox.processes.start("sleep 30");
+  const drained = (async () => {
+    for await (const _event of process.output()) {
+      // no events expected from hanging mock
+    }
+  })();
+  await process.kill();
+  await Promise.race([
+    drained,
+    new Promise((_, reject) => setTimeout(() => reject(new Error("output hung after kill")), 500)),
+  ]);
+  expect(kill).toHaveBeenCalled();
+  expect(await process.status()).toBe("exited");
+  await sandbox.stop();
+});

--- a/packages/sdk/tests/types/provider-contracts.typecheck.ts
+++ b/packages/sdk/tests/types/provider-contracts.typecheck.ts
@@ -1,5 +1,6 @@
 import type { Sandbox as DaytonaNative } from "@daytona/sdk";
 import type { Sandbox as E2BNative } from "e2b";
+import type { Sandbox as RailwayNative } from "railway";
 import type { Sandbox as VercelNative } from "@vercel/sandbox";
 import type { Box as UpstashNative } from "@upstash/box";
 import type { SandboxProvider } from "../../src/core/provider";
@@ -7,6 +8,7 @@ import { agentos, type AgentOsSandbox } from "../../src/providers/agentos";
 import { daytona } from "../../src/providers/daytona";
 import { e2b } from "../../src/providers/e2b";
 import { local, type LocalSandbox } from "../../src/providers/local";
+import { railway } from "../../src/providers/railway";
 import { vercel } from "../../src/providers/vercel";
 import { upstash } from "../../src/providers/upstash";
 
@@ -16,6 +18,7 @@ const e2bContract: SandboxProvider<E2BNative> = e2b();
 const daytonaContract: SandboxProvider<DaytonaNative> = daytona();
 const vercelContract: SandboxProvider<VercelNative> = vercel();
 const upstashContract: SandboxProvider<UpstashNative> = upstash();
+const railwayContract: SandboxProvider<RailwayNative> = railway();
 void [
   localContract,
   agentosContract,
@@ -23,6 +26,7 @@ void [
   daytonaContract,
   vercelContract,
   upstashContract,
+  railwayContract,
 ];
 
 // @ts-expect-error Explicit access-token authentication requires the complete credential triple.

--- a/packages/sdk/tests/types/public-imports.typecheck.ts
+++ b/packages/sdk/tests/types/public-imports.typecheck.ts
@@ -1,4 +1,4 @@
-// @ts-expect-error Providers outside the six launch integrations are not exported.
+// @ts-expect-error Providers outside the supported integrations are not exported.
 import "@opencoredev/sandbox-sdk/modal";
 // @ts-expect-error Internal runtime contracts are not public subpaths.
 import "@opencoredev/sandbox-sdk/core/provider";

--- a/packages/sdk/tests/types/raw.typecheck.ts
+++ b/packages/sdk/tests/types/raw.typecheck.ts
@@ -1,5 +1,6 @@
 import type { Sandbox as DaytonaNative } from "@daytona/sdk";
 import type { Sandbox as E2BNative } from "e2b";
+import type { Sandbox as RailwayNative } from "railway";
 import type { Sandbox as VercelNative } from "@vercel/sandbox";
 import type { Box as UpstashNative } from "@upstash/box";
 import { createSandbox } from "../../src";
@@ -7,6 +8,7 @@ import { agentos, type AgentOsSandbox } from "../../src/providers/agentos";
 import { daytona } from "../../src/providers/daytona";
 import { e2b } from "../../src/providers/e2b";
 import { local, type LocalSandbox } from "../../src/providers/local";
+import { railway } from "../../src/providers/railway";
 import { vercel } from "../../src/providers/vercel";
 import { upstash } from "../../src/providers/upstash";
 
@@ -17,7 +19,16 @@ async function rawTypes() {
   const daytonaSandbox: DaytonaNative = (await createSandbox({ provider: daytona() })).raw;
   const vercelSandbox: VercelNative = (await createSandbox({ provider: vercel() })).raw;
   const upstashSandbox: UpstashNative = (await createSandbox({ provider: upstash() })).raw;
-  void [localSandbox, agentosSandbox, e2bSandbox, daytonaSandbox, vercelSandbox, upstashSandbox];
+  const railwaySandbox: RailwayNative = (await createSandbox({ provider: railway() })).raw;
+  void [
+    localSandbox,
+    agentosSandbox,
+    e2bSandbox,
+    daytonaSandbox,
+    vercelSandbox,
+    upstashSandbox,
+    railwaySandbox,
+  ];
 }
 
 async function disposableSandbox() {

--- a/packages/sdk/tsdown.config.ts
+++ b/packages/sdk/tsdown.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     "src/providers/daytona/index.ts",
     "src/providers/vercel/index.ts",
     "src/providers/upstash/index.ts",
+    "src/providers/railway/index.ts",
     "src/ai/index.ts",
     "src/ai/harness.ts",
     "src/eve/index.ts",
@@ -30,5 +31,6 @@ export default defineConfig({
     "@ai-sdk/harness",
     "@mastra/core/workspace",
     "eve",
+    "railway",
   ],
 });

--- a/skills/sandbox-sdk/SKILL.md
+++ b/skills/sandbox-sdk/SKILL.md
@@ -5,7 +5,7 @@ description: Use when implementing isolated code execution with @opencoredev/san
 
 # Sandbox SDK
 
-Use one normalized TypeScript interface across Local, E2B, Daytona, Vercel Sandbox, and Upstash Box.
+Use one normalized TypeScript interface across Local, E2B, Daytona, Vercel Sandbox, Upstash Box, and Railway.
 
 ## Start here
 


### PR DESCRIPTION
## Summary

- Add Railway Sandboxes provider via the official `railway` SDK
- Export as `@opencoredev/sandbox-sdk/railway`
- Docs, metadata, example, and unit tests

## Test plan

- [x] SDK build + typecheck
- [x] Unit tests (including railway adapter)