### PR TITLE
Add Agent37 provider

### DIFF
--- a/.github/workflows/live-compatibility.yml
+++ b/.github/workflows/live-compatibility.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        provider: [e2b, daytona, vercel, upstash]
+        provider: [e2b, daytona, vercel, upstash, agent37]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -27,6 +27,7 @@ jobs:
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           UPSTASH_BOX_API_KEY: ${{ secrets.UPSTASH_BOX_API_KEY }}
+          AGENT37_API_KEY: ${{ secrets.AGENT37_API_KEY }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0 # v7.0.1
         if: always()
         with:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img alt="Sandbox SDK with supported provider logos" src="./Background-with-text.png" width="820" />
 </p>
 
-Run the same TypeScript sandbox code on Local, E2B, Daytona, Vercel Sandbox, or Upstash Box.
+Run the same TypeScript sandbox code on Local, E2B, Daytona, Vercel Sandbox, Upstash Box, or Agent37.
 
 ## Install
 
@@ -35,8 +35,9 @@ Node.js 24 and Bun run this syntax directly. On Node.js 22, compile TypeScript t
 | [Daytona](https://sandbox-sdk.app/docs/providers/daytona)       | Cloud workspace         | Persistent projects and GPUs            |
 | [Vercel Sandbox](https://sandbox-sdk.app/docs/providers/vercel) | Hosted Linux sandbox    | Coding agents and persistent workspaces |
 | [Upstash Box](https://sandbox-sdk.app/docs/providers/upstash)   | Durable cloud container | Serverless agents and long-lived state  |
+| [Agent37](https://sandbox-sdk.app/docs/providers/agent37)       | Cloud computer          | Persistent instances and custom images  |
 
-Local is included. Cloud providers use their official SDKs and credentials.
+Local is included. Cloud providers use their official SDKs and credentials; Agent37 needs only its REST API key.
 
 ## Documentation
 

--- a/apps/fumadocs/content/docs/api/ports.mdx
+++ b/apps/fumadocs/content/docs/api/ports.mdx
@@ -20,12 +20,13 @@ const response = await preview.request?.("/health");
 
 Authenticated adapters keep preview credentials inside `request()`. `toJSON()` never returns credential-bearing headers and redacts URL query values.
 
-| Provider       | Port behavior                                                      |
-| -------------- | ------------------------------------------------------------------ |
-| Local          | Returns a private URL and bridges calls through `request()`.       |
-| E2B            | Returns an E2B host and uses a native access token when required.  |
-| Daytona        | Returns a public or token-authenticated preview URL.               |
-| Vercel Sandbox | Registers the port and returns a public `vercel.run` route.        |
-| Upstash Box    | Returns a public URL or keeps its bearer token inside `request()`. |
+| Provider       | Port behavior                                                                                                   |
+| -------------- | --------------------------------------------------------------------------------------------------------------- |
+| Local          | Returns a private URL and bridges calls through `request()`.                                                    |
+| E2B            | Returns an E2B host and uses a native access token when required.                                               |
+| Daytona        | Returns a public or token-authenticated preview URL.                                                            |
+| Vercel Sandbox | Registers the port and returns a public `vercel.run` route.                                                     |
+| Upstash Box    | Returns a public URL or keeps its bearer token inside `request()`.                                              |
+| Agent37        | Returns a key-authenticated URL with the key inside `request()`, or a permanent public URL with `public: true`. |
 
 Compare provider preview behavior in [Providers](/docs/providers).

--- a/apps/fumadocs/content/docs/api/sandboxes.mdx
+++ b/apps/fumadocs/content/docs/api/sandboxes.mdx
@@ -40,13 +40,13 @@ Node.js 24 and Bun run `await using` directly. TypeScript 5.2 or newer can compi
 
 ## Sandbox properties
 
-| Property       | Type                 | Description                                         |
-| -------------- | -------------------- | --------------------------------------------------- |
-| `id`           | `string`             | Provider or adapter identifier for this sandbox.    |
-| `provider`     | `ProviderName`       | `local`, `e2b`, `daytona`, `vercel`, or `upstash`.  |
-| `cwd`          | `string`             | Normalized working directory.                       |
-| `capabilities` | `CapabilityMap`      | Supported operations and their modes.               |
-| `raw`          | Provider-native type | Typed access to the underlying provider SDK object. |
+| Property       | Type                 | Description                                                   |
+| -------------- | -------------------- | ------------------------------------------------------------- |
+| `id`           | `string`             | Provider or adapter identifier for this sandbox.              |
+| `provider`     | `ProviderName`       | `local`, `e2b`, `daytona`, `vercel`, `upstash`, or `agent37`. |
+| `cwd`          | `string`             | Normalized working directory.                                 |
+| `capabilities` | `CapabilityMap`      | Supported operations and their modes.                         |
+| `raw`          | Provider-native type | Typed access to the underlying provider SDK object.           |
 
 ## Automatic cleanup
 

--- a/apps/fumadocs/content/docs/index.mdx
+++ b/apps/fumadocs/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: Quickstart
 description: Install Sandbox SDK, run a Local sandbox, and switch to a cloud provider.
 ---
 
-Sandbox SDK uses one TypeScript API for Local, E2B, Daytona, Vercel Sandbox, and Upstash Box.
+Sandbox SDK uses one TypeScript API for Local, E2B, Daytona, Vercel Sandbox, Upstash Box, and Agent37.
 
 ## Install
 
@@ -13,7 +13,7 @@ bun add @opencoredev/sandbox-sdk
 
 Use Node.js 22 or 24, or Bun 1.3 or newer.
 
-Local is included and needs no account or API key. Cloud providers need their official SDK and credentials; each [provider page](/docs/providers) has the setup details.
+Local is included and needs no account or API key. Cloud providers need credentials, and most need their official SDK; each [provider page](/docs/providers) has the setup details.
 
 ## Run your first sandbox
 

--- a/apps/fumadocs/content/docs/integrations/mastra.mdx
+++ b/apps/fumadocs/content/docs/integrations/mastra.mdx
@@ -25,6 +25,7 @@ The Local provider is included. Install the native SDK only for the cloud provid
 | Daytona        | `@daytona/sdk`     |
 | Vercel Sandbox | `@vercel/sandbox`  |
 | Upstash Box    | `@upstash/box`     |
+| Agent37        | None               |
 
 Configure the provider's credentials as described in its [provider guide](/docs/providers). The agent example below also expects `OPENAI_API_KEY` for its selected model.
 

--- a/apps/fumadocs/content/docs/providers/agent37.mdx
+++ b/apps/fumadocs/content/docs/providers/agent37.mdx
@@ -1,0 +1,90 @@
+---
+title: Agent37
+description: Run persistent Agent37 instances through the normalized SDK API.
+icon: agent37
+---
+
+Agent37 provides persistent cloud computers with files, processes, key-authenticated or public preview URLs, and custom Docker templates. The adapter drives the Agent37 REST APIs directly over `fetch`.
+
+## Installation
+
+```bash title="Terminal"
+bun add @opencoredev/sandbox-sdk
+```
+
+No provider package is required.
+
+## Authentication
+
+Set `AGENT37_API_KEY`, or pass `apiKey` to `agent37()`.
+
+## Run a command
+
+```ts title="agent37.ts"
+import { createSandbox } from "@opencoredev/sandbox-sdk";
+import { agent37 } from "@opencoredev/sandbox-sdk/agent37";
+
+await using sandbox = await createSandbox({ provider: agent37() });
+const result = await sandbox.run("node --version");
+console.log(result.stdout);
+```
+
+## Run an agent
+
+Export one provider instance and pass it to [AI SDK](/docs/integrations/ai-sdk), [HarnessAgent](/docs/integrations/ai-sdk-harness), [Eve](/docs/integrations/eve), or [Mastra](/docs/integrations/mastra).
+
+```ts title="agent-provider.ts"
+import { agent37 } from "@opencoredev/sandbox-sdk/agent37";
+
+export const agentSandboxProvider = agent37();
+```
+
+## Files and processes
+
+```ts title="workspace.ts"
+await sandbox.files.write("index.mjs", `console.log("ready")`);
+const process = await sandbox.processes.start("node index.mjs");
+
+for await (const event of process.output()) {
+  console.log(event.data);
+}
+```
+
+Agent37 supports persistent files, background processes with combined output, and cancellation. Foreground commands return separate stdout and stderr. Normalized stdin is not available.
+
+## Ports
+
+Preview URLs are key-authenticated by default. `preview.request()` injects the key, so it never appears in the URL or serialized output. Pass `public: true` to expose ports at permanent unauthenticated public-port URLs instead.
+
+```ts title="ports.ts"
+const preview = await sandbox.ports.expose(3000);
+const response = await preview.request?.("/api/status");
+```
+
+The bare `/health` path is answered by the Agent37 edge itself and never reaches your service, so serve health checks on another path.
+
+## Options
+
+| Option               | Type                                               | Default                      | Behavior                                            |
+| -------------------- | -------------------------------------------------- | ---------------------------- | --------------------------------------------------- |
+| `apiKey`             | `string`                                           | `AGENT37_API_KEY`            | Authenticates Hosting API and gateway requests.     |
+| `template`           | `string`                                           | `agent37-hermes`             | Selects a system or workspace template.             |
+| `resources`          | `{ cpu?: number; memory?: number; disk?: number }` | Template defaults            | Sets the instance shape.                            |
+| `name`               | `string`                                           | None                         | Stores a label on the instance.                     |
+| `autoSleep`          | `boolean`                                          | `false`                      | Checkpoints the idle instance to disk-only billing. |
+| `idleTimeoutSeconds` | `number`                                           | `300`                        | Idle seconds before auto-sleep, from 60 to 86400.   |
+| `public`             | `boolean`                                          | `false`                      | Controls public-port or key-authenticated URLs.     |
+| `baseUrl`            | `string`                                           | `https://api.agent37.com/v1` | Overrides the Hosting API base URL.                 |
+
+## Behavior
+
+- The instance disk persists. Managed sessions stop and start the instance, and files survive the pause.
+- `sandbox.stop()` permanently deletes the instance.
+- Foreground commands cap at 280 seconds and 512 KB per stream; background processes stream one combined output through files on the instance.
+- Snapshots are not supported. The persistent disk covers stop and resume instead.
+- Custom Docker templates work through `template` when the image builds on an Agent37 gateway-bearing base image (such as `hermes-base`); the adapter needs the in-instance gateway for boot detection and file operations.
+- Native instance controls (`hosting()`, `gateway()`, `exec()`, `stop()`, `start()`, `restart()`, `delete()`) remain typed on `sandbox.raw`.
+
+## Read next
+
+See [Ports](/docs/api/ports), compare exact modes in [Compatibility](/docs/reference/compatibility), or connect Agent37 to [HarnessAgent](/docs/integrations/ai-sdk-harness).

--- a/apps/fumadocs/content/docs/providers/index.mdx
+++ b/apps/fumadocs/content/docs/providers/index.mdx
@@ -6,13 +6,14 @@ icon: providers
 
 Every provider supports files, foreground commands, background processes, streaming, and cleanup. Choose based on the optional behavior your workload needs.
 
-| Provider                                 | Vendor documentation                    | Best for                             | Runtime         | Persistence    | Preview                 | Snapshot             |
-| ---------------------------------------- | --------------------------------------- | ------------------------------------ | --------------- | -------------- | ----------------------- | -------------------- |
-| [Local](/docs/providers/local)           | <ProviderDocsLink provider="local" />   | Development, CI, self-hosting        | AgentOS VM      | Process-scoped | Private bridge          | Filesystem + restore |
-| [E2B](/docs/providers/e2b)               | <ProviderDocsLink provider="e2b" />     | Hosted coding agents                 | Linux sandbox   | Ephemeral      | Authenticated           | Template             |
-| [Daytona](/docs/providers/daytona)       | <ProviderDocsLink provider="daytona" /> | Persistent workspaces, GPUs          | Linux workspace | Persistent     | Public or authenticated | Native API           |
-| [Vercel Sandbox](/docs/providers/vercel) | <ProviderDocsLink provider="vercel" />  | Coding agents, persistent workspaces | Linux sandbox   | Default on     | Public                  | Filesystem           |
-| [Upstash Box](/docs/providers/upstash)   | <ProviderDocsLink provider="upstash" /> | Durable serverless boxes             | Linux container | Persistent     | Public or bearer token  | Filesystem           |
+| Provider                                 | Vendor documentation                    | Best for                             | Runtime         | Persistence    | Preview                     | Snapshot             |
+| ---------------------------------------- | --------------------------------------- | ------------------------------------ | --------------- | -------------- | --------------------------- | -------------------- |
+| [Local](/docs/providers/local)           | <ProviderDocsLink provider="local" />   | Development, CI, self-hosting        | AgentOS VM      | Process-scoped | Private bridge              | Filesystem + restore |
+| [E2B](/docs/providers/e2b)               | <ProviderDocsLink provider="e2b" />     | Hosted coding agents                 | Linux sandbox   | Ephemeral      | Authenticated               | Template             |
+| [Daytona](/docs/providers/daytona)       | <ProviderDocsLink provider="daytona" /> | Persistent workspaces, GPUs          | Linux workspace | Persistent     | Public or authenticated     | Native API           |
+| [Vercel Sandbox](/docs/providers/vercel) | <ProviderDocsLink provider="vercel" />  | Coding agents, persistent workspaces | Linux sandbox   | Default on     | Public                      | Filesystem           |
+| [Upstash Box](/docs/providers/upstash)   | <ProviderDocsLink provider="upstash" /> | Durable serverless boxes             | Linux container | Persistent     | Public or bearer token      | Filesystem           |
+| [Agent37](/docs/providers/agent37)       | <ProviderDocsLink provider="agent37" /> | Persistent agent computers           | Linux instance  | Persistent     | Key-authenticated or public | —                    |
 
 Optional semantics differ. Check the generated [compatibility matrix](/docs/reference/compatibility) before depending on stdin, restore, resume, networking, GPUs, or a custom image.
 

--- a/apps/fumadocs/content/docs/providers/meta.json
+++ b/apps/fumadocs/content/docs/providers/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Providers",
   "icon": "providers",
-  "pages": ["index", "local", "e2b", "daytona", "vercel", "upstash"]
+  "pages": ["index", "local", "e2b", "daytona", "vercel", "upstash", "agent37"]
 }

--- a/apps/fumadocs/content/docs/reference/compatibility.mdx
+++ b/apps/fumadocs/content/docs/reference/compatibility.mdx
@@ -16,6 +16,7 @@ The matrix is generated from the same capability declarations exported by the ad
 - Vercel and E2B snapshots create provider-native artifacts, but restore creates a new native sandbox and stays on `raw`.
 - Daytona persistence, PTYs, networking, images, and GPUs are provider-native capabilities beyond the normalized core.
 - Upstash Box provides durable filesystems, pause and resume, network policies, and public or bearer-token URLs; snapshot restore creates a new native Box.
+- Agent37 instances keep a persistent disk across stop and resume; snapshots and stdin are unsupported, and preview URLs are key-authenticated through `preview.request()` unless `public: true`.
 
 ## Read next
 

--- a/apps/fumadocs/content/docs/reference/package-exports.mdx
+++ b/apps/fumadocs/content/docs/reference/package-exports.mdx
@@ -19,6 +19,7 @@ import { e2b } from "@opencoredev/sandbox-sdk/e2b";
 import { daytona } from "@opencoredev/sandbox-sdk/daytona";
 import { vercel } from "@opencoredev/sandbox-sdk/vercel";
 import { upstash } from "@opencoredev/sandbox-sdk/upstash";
+import { agent37 } from "@opencoredev/sandbox-sdk/agent37";
 ```
 
 Each adapter export includes its options type, native sandbox type, and capability declaration.

--- a/apps/fumadocs/src/app/(home)/partners/page.tsx
+++ b/apps/fumadocs/src/app/(home)/partners/page.tsx
@@ -28,7 +28,7 @@ export default function PartnersPage() {
       <article className="prose mt-12 max-w-3xl">
         <h2>What we maintain</h2>
         <p>
-          OpenCore maintains five integrations: Local, E2B, Daytona, Vercel Sandbox and Upstash Box.
+          OpenCore maintains six integrations: Local, E2B, Daytona, Vercel Sandbox, Upstash Box and Agent37.
           Local is powered by AgentOS under the hood. The unified API covers files, commands,
           processes, ports, capabilities, errors, cleanup and typed native access.
         </p>

--- a/apps/fumadocs/src/components/docs-icon.tsx
+++ b/apps/fumadocs/src/components/docs-icon.tsx
@@ -27,6 +27,8 @@ export function ProviderLogo({ id, ...props }: IconProps & { id: string }) {
       return <VercelLogo {...props} />;
     case "upstash":
       return <UpstashLogo {...props} />;
+    case "agent37":
+      return <Agent37Logo {...props} />;
     default:
       return <HugeiconsIcon icon={ServerStack01Icon} className={props.className} />;
   }
@@ -42,6 +44,7 @@ export function resolveDocsIcon(icon: string | undefined): ReactNode {
     case "daytona":
     case "vercel":
     case "upstash":
+    case "agent37":
       return <ProviderLogo id={icon} />;
     case "integrations":
       return <HugeiconsIcon icon={PlugSocketIcon} />;
@@ -96,6 +99,18 @@ function UpstashLogo(props: IconProps) {
       <path
         fill="currentColor"
         d="M13.803 0c-2.61 0-5.22.995-7.211 2.986-3.982 3.983-3.982 10.44 0 14.422a5.1 5.1 0 0 0 7.21-7.21L12 12a2.55 2.55 0 0 1-3.605 3.605A7.649 7.649 0 0 1 19.21 4.79l1.803-1.803A10.17 10.17 0 0 0 13.803 0M12 12a2.55 2.55 0 0 1 3.605-3.605A7.649 7.649 0 0 1 4.79 19.21l-1.803 1.803c3.983 3.982 10.44 3.982 14.422 0s3.982-10.44 0-14.422A5.08 5.08 0 0 0 13.803 5.1a5.1 5.1 0 0 0-3.605 8.703z"
+      />
+    </svg>
+  );
+}
+
+function Agent37Logo(props: IconProps) {
+  return (
+    <svg {...iconProps} {...props} viewBox="0 0 24 24">
+      <path
+        fill="currentColor"
+        fillRule="evenodd"
+        d="M4.5 2h15A2.5 2.5 0 0 1 22 4.5v15a2.5 2.5 0 0 1-2.5 2.5h-15A2.5 2.5 0 0 1 2 19.5v-15A2.5 2.5 0 0 1 4.5 2Zm0 2a.5.5 0 0 0-.5.5v15a.5.5 0 0 0 .5.5h15a.5.5 0 0 0 .5-.5v-15a.5.5 0 0 0-.5-.5h-15Zm2.44 4.06 1.41-1.41L12.71 11l-4.36 4.35-1.41-1.41L9.88 11 6.94 8.06ZM12.5 14.5h5v2h-5v-2Z"
       />
     </svg>
   );

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add the Agent37 provider: run sandboxes on persistent Agent37 instances through the `@opencoredev/sandbox-sdk/agent37` subpath and `AGENT37_API_KEY`, using the Agent37 REST APIs with no SDK dependency.
+
 ## @opencoredev/sandbox-sdk@0.1.1
 
 - Add `Symbol.asyncDispose` to `Sandbox` so `await using` provides automatic cleanup.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -2,7 +2,7 @@
   <img alt="Sandbox SDK with supported provider logos" src="https://raw.githubusercontent.com/opencoredev/sandbox-sdk/main/Background-with-text.png" width="820" />
 </p>
 
-Run the same TypeScript sandbox code on Local, E2B, Daytona, Vercel Sandbox, or Upstash Box.
+Run the same TypeScript sandbox code on Local, E2B, Daytona, Vercel Sandbox, Upstash Box, or Agent37.
 
 ## Install
 
@@ -35,8 +35,9 @@ Node.js 24 and Bun run this syntax directly. On Node.js 22, compile TypeScript t
 | [Daytona](https://sandbox-sdk.app/docs/providers/daytona)       | Cloud workspace         | Persistent projects and GPUs            |
 | [Vercel Sandbox](https://sandbox-sdk.app/docs/providers/vercel) | Hosted Linux sandbox    | Coding agents and persistent workspaces |
 | [Upstash Box](https://sandbox-sdk.app/docs/providers/upstash)   | Durable cloud container | Serverless agents and long-lived state  |
+| [Agent37](https://sandbox-sdk.app/docs/providers/agent37)       | Cloud computer          | Persistent instances and custom images  |
 
-Local is included. Cloud providers use their official SDKs and credentials.
+Local is included. Cloud providers use their official SDKs and credentials; Agent37 needs only its REST API key.
 
 ## Documentation
 

--- a/packages/sdk/examples/agent37.ts
+++ b/packages/sdk/examples/agent37.ts
@@ -1,0 +1,5 @@
+import { createSandbox } from "../src";
+import { agent37 } from "../src/providers/agent37";
+
+await using sandbox = await createSandbox({ provider: agent37() });
+console.log((await sandbox.run("printf agent37")).stdout);

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -46,6 +46,10 @@
       "types": "./dist/providers/upstash/index.d.mts",
       "import": "./dist/providers/upstash/index.mjs"
     },
+    "./agent37": {
+      "types": "./dist/providers/agent37/index.d.mts",
+      "import": "./dist/providers/agent37/index.mjs"
+    },
     "./metadata": {
       "types": "./dist/metadata.d.mts",
       "import": "./dist/metadata.mjs"
@@ -90,7 +94,8 @@
     "test:live:integrations": "bun test tests/live/integrations.test.ts",
     "test:live:mastra": "bun test tests/live/mastra.test.ts",
     "test:live:vercel": "bun test tests/live/vercel.test.ts",
-    "test:live:upstash": "bun test tests/live/upstash.test.ts"
+    "test:live:upstash": "bun test tests/live/upstash.test.ts",
+    "test:live:agent37": "bun test tests/live/agent37.test.ts"
   },
   "dependencies": {
     "@rivet-dev/agentos-core": "^0.2.7"

--- a/packages/sdk/scripts/run-live.ts
+++ b/packages/sdk/scripts/run-live.ts
@@ -14,12 +14,14 @@ const missingCredentials =
       ? !process.env.DAYTONA_API_KEY
       : id === "upstash"
         ? !process.env.UPSTASH_BOX_API_KEY
-        : !process.env.VERCEL_OIDC_TOKEN &&
-          !(
-            process.env.VERCEL_TOKEN &&
-            process.env.VERCEL_TEAM_ID &&
-            process.env.VERCEL_PROJECT_ID
-          );
+        : id === "agent37"
+          ? !process.env.AGENT37_API_KEY
+          : !process.env.VERCEL_OIDC_TOKEN &&
+            !(
+              process.env.VERCEL_TOKEN &&
+              process.env.VERCEL_TEAM_ID &&
+              process.env.VERCEL_PROJECT_ID
+            );
 const processResult = missingCredentials
   ? null
   : Bun.spawn(["bun", "test", `tests/live/${id}.test.ts`], {

--- a/packages/sdk/src/core/types.ts
+++ b/packages/sdk/src/core/types.ts
@@ -1,4 +1,4 @@
-export const providerNames = ["local", "e2b", "daytona", "vercel", "upstash"] as const;
+export const providerNames = ["local", "e2b", "daytona", "vercel", "upstash", "agent37"] as const;
 export type ProviderName = (typeof providerNames)[number];
 
 export const capabilityNames = [

--- a/packages/sdk/src/metadata.ts
+++ b/packages/sdk/src/metadata.ts
@@ -1,4 +1,5 @@
 import {
+  agent37Capabilities,
   daytonaCapabilities,
   e2bCapabilities,
   localCapabilities,
@@ -133,6 +134,25 @@ export const providers: readonly ProviderMetadata[] = [
       "Captures persistent workspace state. Restoring creates a new Box and remains available through raw.",
     runtimeLimitations:
       "Durable Debian or Alpine boxes with Node.js, Python, Go, Ruby, or Rust runtimes.",
+  },
+  {
+    id: "agent37",
+    displayName: "Agent37",
+    officialUrl: "https://www.agent37.com/docs",
+    packageName: null,
+    packageVersion: "v1",
+    capabilities: agent37Capabilities,
+    environmentVariables: ["AGENT37_API_KEY"],
+    technicalStatus: "experimental",
+    providerReviewed: true,
+    sponsor: false,
+    liveTest: null,
+    portBehavior:
+      "Derives key-authenticated preview URLs for any port; the key stays inside ExposedPort.request(). Pass public: true for permanent unauthenticated public-port URLs.",
+    snapshotBehavior:
+      "Snapshots are not supported. The instance disk persists across stop, start, and resume instead.",
+    runtimeLimitations:
+      "Persistent cloud instances driven over the Agent37 REST APIs with no SDK dependency. Foreground commands cap at 280 seconds and 512 KB per stream; background processes stream through files. Templates must build on a gateway-bearing Agent37 base image.",
   },
 ];
 

--- a/packages/sdk/src/providers/agent37/index.ts
+++ b/packages/sdk/src/providers/agent37/index.ts
@@ -1,0 +1,695 @@
+import { randomUUID } from "node:crypto";
+import { SandboxError, type SandboxErrorCode } from "../../core/errors";
+import type { SandboxProvider } from "../../core/provider";
+import type {
+  CommandInput,
+  ProcessOutputEvent,
+  ProcessStatus,
+  RunOptions,
+  SandboxDirectoryEntry,
+  SandboxProcess,
+} from "../../core/types";
+import { withManagedSessions } from "../../internal/managed-provider";
+import {
+  commandString,
+  portResult,
+  toUint8Array,
+  unsupported,
+  unsupportedSnapshots,
+} from "../../internal/provider-utils";
+import { agent37Capabilities } from "../capabilities";
+
+const DEFAULT_BASE_URL = "https://api.agent37.com/v1";
+const DEFAULT_BOOT_TIMEOUT_MS = 180_000;
+const POLL_INTERVAL_MS = 500;
+const OUTPUT_CHUNK_BYTES = 262_144;
+/** The platform kills any exec call at 280 seconds; longer jobs must run in the background. */
+const EXEC_CAP_MS = 280_000;
+
+export interface Agent37Options {
+  /** Workspace API key (`sk_live_...`). Defaults to `AGENT37_API_KEY`. */
+  apiKey?: string;
+  /**
+   * Template to create instances from: a system template such as `agent37-hermes`,
+   * `agent37-hermes-small`, or `agent37-openclaw` (optionally version-pinned with `@<tag>`), or
+   * one of your workspace templates. Omitted, the platform default (`agent37-hermes`) is used.
+   * A workspace template must be built on an Agent37 gateway-bearing base image (such as
+   * `hermes-base`): the adapter needs the in-instance gateway for boot detection and file
+   * operations, so an image without it makes `create()` time out.
+   */
+  template?: string;
+  /** Instance shape, for example `{ cpu: 2, memory: 4, disk: 6 }`. Omitted fields use template defaults. */
+  resources?: { cpu?: number; memory?: number; disk?: number };
+  /** A label stored on the instance. */
+  name?: string;
+  /**
+   * Checkpoint the instance when idle; it bills disk-only while sleeping. The platform measures
+   * idleness on instance-URL traffic only, so command-heavy workloads can still fall asleep.
+   * Sandbox operations wake a sleeping instance automatically, at the cost of one slower
+   * operation after each sleep.
+   */
+  autoSleep?: boolean;
+  /** Idle seconds before auto-sleep, from 60 to 86400. Only meaningful with `autoSleep`. */
+  idleTimeoutSeconds?: number;
+  /**
+   * Expose ports at permanent unauthenticated public-port URLs. Defaults to false, which derives
+   * key-authenticated preview URLs and keeps the key inside `ExposedPort.request()`.
+   */
+  public?: boolean;
+  /** Hosting API base URL. */
+  baseUrl?: string;
+}
+
+/** The Agent37 instance object returned by the Hosting API. */
+export interface Agent37InstanceRecord {
+  id: string;
+  status: string;
+  template: string;
+  resources: { cpu: number; memory: number; disk: number };
+  url: string;
+  public_ports: Array<{ port: number; url: string; prefix: string | null; created: number }>;
+  name: string | null;
+  user: string | null;
+  metadata: Record<string, unknown> | null;
+  auto_sleep: boolean;
+  idle_timeout_seconds: number;
+  created: number;
+}
+
+export interface Agent37ExecResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  truncated: boolean;
+}
+
+/** Native escape hatch for the Agent37 instance behind a sandbox. */
+export interface Agent37Sandbox {
+  /** The most recent instance object observed from the Hosting API. */
+  readonly instance: Agent37InstanceRecord;
+  /** Requests `https://api.agent37.com/v1/instances/{id}{path}` with Bearer authentication. */
+  hosting(path: string, init?: RequestInit): Promise<Response>;
+  /** Requests `{instance.url}{path}` (the in-instance gateway) with `X-Agent37-Key` authentication. */
+  gateway(path: string, init?: RequestInit): Promise<Response>;
+  /** Runs a shell command through the Hosting API exec endpoint. */
+  exec(command: string): Promise<Agent37ExecResult>;
+  /** Halts the instance. Disk persists and bills alone until `start()`. */
+  stop(): Promise<void>;
+  /** Starts a stopped instance and waits for its gateway to answer. */
+  start(): Promise<void>;
+  /** Recreates the container from the same image and data. */
+  restart(): Promise<void>;
+  /** Deletes the instance permanently. */
+  delete(): Promise<void>;
+}
+
+export { agent37Capabilities } from "../capabilities";
+
+/**
+ * Agent37 provider. Runs sandboxes on persistent Agent37 instances over the Hosting and
+ * gateway REST APIs with no native SDK dependency.
+ */
+export function agent37(options: Agent37Options = {}): SandboxProvider<Agent37Sandbox> {
+  const baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, "");
+  const publicPorts = options.public ?? false;
+
+  return withManagedSessions(
+    {
+      id: "agent37",
+      capabilities: agent37Capabilities,
+      async create(createOptions) {
+        assertNotAborted(createOptions.signal);
+        const apiKey = options.apiKey ?? process.env.AGENT37_API_KEY;
+        if (!apiKey) {
+          throw new SandboxError({
+            code: "authentication",
+            provider: "agent37",
+            operation: "sandbox.create",
+            message: "Set AGENT37_API_KEY or pass apiKey to agent37()",
+          });
+        }
+        const bootTimeout = createOptions.timeout ?? DEFAULT_BOOT_TIMEOUT_MS;
+        const api = new Agent37Api(baseUrl, apiKey);
+        let instance = await api.request<Agent37InstanceRecord>("sandbox.create", "/instances", {
+          method: "POST",
+          body: JSON.stringify({
+            ...(options.template ? { template: options.template } : {}),
+            ...(options.resources ? { resources: options.resources } : {}),
+            ...(options.name ? { name: options.name } : {}),
+            ...(options.autoSleep !== undefined ? { auto_sleep: options.autoSleep } : {}),
+            ...(options.idleTimeoutSeconds !== undefined
+              ? { idle_timeout_seconds: options.idleTimeoutSeconds }
+              : {}),
+          }),
+          signal: createOptions.signal,
+        });
+
+        const hosting = (path: string, init?: RequestInit) =>
+          api.fetch(`/instances/${instance.id}${path}`, init);
+        const gateway = (path: string, init: RequestInit = {}) =>
+          fetch(new URL(path, instance.url), {
+            ...init,
+            headers: {
+              ...Object.fromEntries(new Headers(init.headers)),
+              "x-agent37-key": apiKey,
+            },
+          });
+        const gatewayJson = async <T>(operation: string, path: string, init?: RequestInit) =>
+          api.parse<T>(operation, await gateway(path, init));
+        const execOnce = async (command: string): Promise<Agent37ExecResult> => {
+          const result = await api.request<{
+            exit_code: number;
+            stdout: string;
+            stderr: string;
+            truncated: boolean;
+          }>("process.run", `/instances/${instance.id}/exec`, {
+            method: "POST",
+            body: JSON.stringify({ command }),
+          });
+          return {
+            exitCode: result.exit_code,
+            stdout: result.stdout,
+            stderr: result.stderr,
+            truncated: result.truncated,
+          };
+        };
+        const exec = async (command: string): Promise<Agent37ExecResult> => {
+          try {
+            return await execOnce(command);
+          } catch (error) {
+            // Exec refuses non-running instances and never wakes a sleeper, but any request to
+            // the instance URL does. Probe the gateway (held until the instance restores) and
+            // retry once; a stopped instance does not wake this way, so its error passes through.
+            if (!(error instanceof SandboxError) || error.code !== "invalid_input") throw error;
+            let woke = false;
+            try {
+              const health = await gateway("/v1/health");
+              await health.arrayBuffer().catch(() => {});
+              woke = health.ok;
+            } catch {
+              woke = false;
+            }
+            if (!woke) throw error;
+            return await execOnce(command);
+          }
+        };
+        const waitForGateway = async (operation: string, signal?: AbortSignal) => {
+          const deadline = Date.now() + bootTimeout;
+          while (true) {
+            assertNotAborted(signal);
+            try {
+              const response = await gateway("/v1/health", { signal });
+              if (response.ok) {
+                const body = (await response.json().catch(() => null)) as { ok?: boolean } | null;
+                if (body?.ok) return;
+              } else {
+                await response.arrayBuffer().catch(() => {});
+              }
+            } catch (error) {
+              if (signal?.aborted) throw error;
+            }
+            if (Date.now() >= deadline) {
+              throw new SandboxError({
+                code: "timeout",
+                provider: "agent37",
+                operation,
+                message: `Instance ${instance.id} gateway did not become healthy within ${bootTimeout}ms`,
+              });
+            }
+            await sleep(1_000, signal);
+          }
+        };
+
+        const raw: Agent37Sandbox = {
+          get instance() {
+            return instance;
+          },
+          hosting,
+          gateway,
+          exec,
+          async stop() {
+            await api.request("sandbox.stop", `/instances/${instance.id}/stop`, {
+              method: "POST",
+            });
+            instance = { ...instance, status: "stopped" };
+          },
+          async start() {
+            await api.request("sandbox.resume", `/instances/${instance.id}/start`, {
+              method: "POST",
+            });
+            await waitForGateway("sandbox.resume");
+            instance = { ...instance, status: "running" };
+          },
+          async restart() {
+            await api.request("sandbox.restart", `/instances/${instance.id}/restart`, {
+              method: "POST",
+            });
+            await waitForGateway("sandbox.restart");
+          },
+          async delete() {
+            try {
+              await api.request("sandbox.stop", `/instances/${instance.id}`, {
+                method: "DELETE",
+              });
+            } catch (error) {
+              if (!(error instanceof SandboxError) || error.code !== "not_found") throw error;
+            }
+            instance = { ...instance, status: "deleted" };
+          },
+        };
+
+        let remoteCwd: string;
+        try {
+          await waitForGateway("sandbox.create", createOptions.signal);
+          const workspace = await gatewayJson<{ path: string }>("sandbox.create", "/v1/files", {
+            signal: createOptions.signal,
+          });
+          remoteCwd = workspace.path;
+        } catch (error) {
+          await raw.delete().catch(() => {});
+          throw error;
+        }
+
+        const toRemotePath = (path: string) =>
+          replacePathPrefix(path, createOptions.cwd, remoteCwd);
+        const toVirtualPath = (path: string) =>
+          replacePathPrefix(path, remoteCwd, createOptions.cwd);
+        const scoped = (command: CommandInput, runOptions: RunOptions) =>
+          scopedCommand(command, withEnv(createOptions, runOptions), createOptions.cwd, remoteCwd);
+
+        return {
+          id: instance.id,
+          raw,
+          capabilities: agent37Capabilities,
+          files: {
+            async write(path, value) {
+              const query = new URLSearchParams({ path: toRemotePath(path), overwrite: "true" });
+              await gatewayJson("files.write", `/v1/files/content?${query}`, {
+                method: "PUT",
+                body: new Uint8Array(await toUint8Array(value)),
+              });
+            },
+            async read(path) {
+              const query = new URLSearchParams({ path: toRemotePath(path) });
+              const response = await gateway(`/v1/files/content?${query}`);
+              if (!response.ok) await api.raise("files.read", response);
+              return new Uint8Array(await response.arrayBuffer());
+            },
+            async list(path) {
+              const query = new URLSearchParams({ path: toRemotePath(path) });
+              const listing = await gatewayJson<{
+                entries: Array<{ name: string; path: string; type: string; size: number | null }>;
+              }>("files.list", `/v1/files?${query}`);
+              return listing.entries.map(
+                (entry): SandboxDirectoryEntry => ({
+                  name: entry.name,
+                  path: toVirtualPath(entry.path),
+                  type:
+                    entry.type === "file" || entry.type === "directory" || entry.type === "symlink"
+                      ? entry.type
+                      : "unknown",
+                  size: entry.size ?? undefined,
+                }),
+              );
+            },
+            async mkdir(path) {
+              const query = new URLSearchParams({ path: toRemotePath(path) });
+              await gatewayJson("files.mkdir", `/v1/files/dir?${query}`, { method: "POST" });
+            },
+            async remove(path) {
+              const remote = toRemotePath(path);
+              if (remote === "/") {
+                throw new SandboxError({
+                  code: "invalid_input",
+                  provider: "agent37",
+                  operation: "files.remove",
+                  message: "Cannot remove the instance filesystem root",
+                });
+              }
+              const query = new URLSearchParams({ path: remote });
+              await gatewayJson("files.remove", `/v1/files?${query}`, { method: "DELETE" });
+            },
+            async exists(path) {
+              const result = await exec(`test -e ${shellQuote(toRemotePath(path))}`);
+              return result.exitCode === 0;
+            },
+          },
+          async run(command, runOptions) {
+            assertNotAborted(runOptions.signal);
+            const started = performance.now();
+            let result: Agent37ExecResult;
+            try {
+              result = await exec(scoped(command, runOptions));
+            } catch (error) {
+              const elapsed = performance.now() - started;
+              if (
+                error instanceof SandboxError &&
+                error.code === "unavailable" &&
+                elapsed >= EXEC_CAP_MS - 15_000
+              ) {
+                throw new SandboxError({
+                  code: "timeout",
+                  provider: "agent37",
+                  operation: "process.run",
+                  message:
+                    "Command exceeded the 280-second Agent37 exec cap; run longer jobs with processes.start()",
+                  cause: error,
+                });
+              }
+              throw error;
+            }
+            if (runOptions.timeout !== undefined && result.exitCode === 124) {
+              throw new SandboxError({
+                code: "timeout",
+                provider: "agent37",
+                operation: "process.run",
+                message: `Command timed out after ${runOptions.timeout}ms`,
+              });
+            }
+            return {
+              stdout: result.stdout,
+              stderr: result.stderr,
+              exitCode: result.exitCode,
+              success: result.exitCode === 0,
+              durationMs: Math.round(performance.now() - started),
+            };
+          },
+          async start(command, runOptions) {
+            assertNotAborted(runOptions.signal);
+            const dir = `/tmp/.sandbox-sdk/${randomUUID()}`;
+            const outputPath = `${dir}/output`;
+            const exitPath = `${dir}/exit`;
+            const inner = scoped(command, runOptions);
+            const wrapper = `${inner} > ${shellQuote(outputPath)} 2>&1; echo $? > ${shellQuote(exitPath)}`;
+            const daemonized = `sh -c ${shellQuote(wrapper)} </dev/null >/dev/null 2>&1 &`;
+            const launcher =
+              `mkdir -p ${shellQuote(dir)} && ` +
+              `if command -v setsid >/dev/null 2>&1; then g=group; setsid ${daemonized} else g=solo; ${daemonized} fi; ` +
+              `echo "$! $g"`;
+            const launched = await exec(launcher);
+            const [pidText, grouping] = launched.stdout.trim().split(" ");
+            const pid = Number.parseInt(pidText ?? "", 10);
+            if (launched.exitCode !== 0 || !Number.isInteger(pid) || pid <= 0) {
+              throw new SandboxError({
+                code: "process_failed",
+                provider: "agent37",
+                operation: "process.start",
+                message: `Failed to start background process${launched.stderr ? `: ${launched.stderr}` : ""}`,
+              });
+            }
+            return backgroundProcess({
+              pid,
+              hasGroup: grouping === "group",
+              outputPath,
+              exitPath,
+              exec,
+            });
+          },
+          async expose(port) {
+            validatePort(port);
+            if (publicPorts) {
+              let entry: { port: number; url: string };
+              try {
+                entry = await api.request<{ port: number; url: string }>(
+                  "ports.expose",
+                  `/instances/${instance.id}/public-ports`,
+                  { method: "POST", body: JSON.stringify({ port }) },
+                );
+              } catch (error) {
+                if (!(error instanceof SandboxError) || error.code !== "conflict") throw error;
+                const current = await api.request<Agent37InstanceRecord>(
+                  "ports.expose",
+                  `/instances/${instance.id}`,
+                );
+                const existing = current.public_ports.find((candidate) => candidate.port === port);
+                if (!existing) throw error;
+                entry = existing;
+              }
+              return portResult(port, entry.url, true, false);
+            }
+            const url = previewUrl(instance.url, port);
+            return portResult(port, url, false, true, (path = "/", init = {}) =>
+              fetch(new URL(path, url), {
+                ...init,
+                headers: {
+                  ...Object.fromEntries(new Headers(init.headers)),
+                  "x-agent37-key": apiKey,
+                },
+              }),
+            );
+          },
+          snapshots: unsupportedSnapshots("agent37"),
+          async stop() {
+            await raw.delete();
+          },
+        };
+      },
+    },
+    [],
+    {
+      stop: (sandbox) => sandbox.raw.stop(),
+      resume: (sandbox) => sandbox.raw.start(),
+      destroy: (sandbox) => sandbox.raw.delete(),
+    },
+  );
+}
+
+class Agent37Api {
+  constructor(
+    private readonly baseUrl: string,
+    private readonly apiKey: string,
+  ) {}
+
+  fetch(path: string, init: RequestInit = {}): Promise<Response> {
+    return fetch(`${this.baseUrl}${path}`, {
+      ...init,
+      headers: {
+        ...Object.fromEntries(new Headers(init.headers)),
+        authorization: `Bearer ${this.apiKey}`,
+        ...(init.body ? { "content-type": "application/json" } : {}),
+      },
+    });
+  }
+
+  async request<T = unknown>(operation: string, path: string, init?: RequestInit): Promise<T> {
+    return this.parse<T>(operation, await this.fetch(path, init));
+  }
+
+  async parse<T>(operation: string, response: Response): Promise<T> {
+    if (!response.ok) await this.raise(operation, response);
+    return (await response.json()) as T;
+  }
+
+  async raise(operation: string, response: Response): Promise<never> {
+    const body = (await response.json().catch(() => null)) as {
+      error?: string | { code?: string; message?: string };
+      message?: string;
+    } | null;
+    const envelope = typeof body?.error === "object" ? body.error : undefined;
+    const code = typeof body?.error === "string" ? body.error : envelope?.code;
+    const message =
+      envelope?.message ??
+      body?.message ??
+      `Agent37 request failed with HTTP ${response.status}${code ? ` (${code})` : ""}`;
+    throw new SandboxError({
+      code: mapErrorCode(response.status, code),
+      provider: "agent37",
+      operation,
+      message,
+      retryable: code ? RETRYABLE_CODES.has(code) : undefined,
+    });
+  }
+}
+
+const RETRYABLE_CODES = new Set([
+  "try_again",
+  "capacity_unavailable",
+  "no_capacity",
+  "wake_timeout",
+  "wake_failed",
+  "container_unreachable",
+  "upstream_unreachable",
+  "instance_saturated",
+  "host_mesh_not_ready",
+  "rate_limited",
+  "upstream_timeout",
+]);
+
+const ERROR_CODE_MAP: Record<string, SandboxErrorCode> = {
+  invalid_api_key: "authentication",
+  forbidden: "permission",
+  tier_limit: "permission",
+  insufficient_balance: "permission",
+  instance_suspended: "permission",
+  not_found: "not_found",
+  file_not_found: "not_found",
+  rate_limited: "rate_limited",
+  upstream_timeout: "timeout",
+  wake_timeout: "unavailable",
+};
+
+function mapErrorCode(status: number, code: string | undefined): SandboxErrorCode {
+  if (code && ERROR_CODE_MAP[code]) return ERROR_CODE_MAP[code];
+  if (status === 400 || status === 413 || status === 422) return "invalid_input";
+  if (status === 401) return "authentication";
+  if (status === 402 || status === 403) return "permission";
+  if (status === 404) return "not_found";
+  if (status === 409 || status === 412) return "conflict";
+  if (status === 429) return "rate_limited";
+  if (status >= 500) return "unavailable";
+  return "internal";
+}
+
+function backgroundProcess(context: {
+  pid: number;
+  hasGroup: boolean;
+  outputPath: string;
+  exitPath: string;
+  exec: (command: string) => Promise<Agent37ExecResult>;
+}): SandboxProcess {
+  const { pid, hasGroup, outputPath, exitPath, exec } = context;
+  let killed = false;
+  let finished: { exitCode: number } | undefined;
+
+  const probe = async (): Promise<{ exitCode: number } | undefined> => {
+    if (finished) return finished;
+    const result = await exec(
+      `if [ -f ${shellQuote(exitPath)} ]; then printf 'exit %s' "$(cat ${shellQuote(exitPath)})"; ` +
+        `elif kill -0 ${pid} 2>/dev/null; then printf running; else printf gone; fi`,
+    );
+    const report = result.stdout.trim();
+    if (report.startsWith("exit ")) {
+      const exitCode = Number.parseInt(report.slice(5), 10);
+      finished = { exitCode: Number.isInteger(exitCode) ? exitCode : 1 };
+    } else if (report === "gone") {
+      // The wrapper died before writing an exit file: the process group was killed.
+      killed = true;
+      finished = { exitCode: 137 };
+    }
+    return finished;
+  };
+
+  const readChunk = async (offset: number): Promise<Uint8Array> => {
+    const result = await exec(
+      `tail -c +${offset + 1} ${shellQuote(outputPath)} 2>/dev/null | head -c ${OUTPUT_CHUNK_BYTES} | base64`,
+    );
+    const encoded = result.stdout.replace(/\s+/g, "");
+    if (!encoded) return new Uint8Array(0);
+    return new Uint8Array(Buffer.from(encoded, "base64"));
+  };
+
+  return {
+    id: String(pid),
+    async status(): Promise<ProcessStatus> {
+      const result = await probe();
+      if (!result) return "running";
+      return killed || result.exitCode === 137 || result.exitCode === 143 ? "killed" : "exited";
+    },
+    async *output(): AsyncIterable<ProcessOutputEvent> {
+      let offset = 0;
+      while (true) {
+        const result = await probe();
+        let chunk = await readChunk(offset);
+        while (chunk.byteLength > 0) {
+          offset += chunk.byteLength;
+          yield { stream: "stdout", data: chunk, timestamp: new Date() };
+          chunk = await readChunk(offset);
+        }
+        if (result) return;
+        await sleep(POLL_INTERVAL_MS);
+      }
+    },
+    async write() {
+      unsupported("agent37", "process.stdin");
+    },
+    async wait() {
+      while (true) {
+        const result = await probe();
+        if (result) return result;
+        await sleep(POLL_INTERVAL_MS);
+      }
+    },
+    async kill(signal = "SIGTERM") {
+      if (finished) return;
+      killed = true;
+      const name = signal === "SIGKILL" || signal === "KILL" || signal === "9" ? "KILL" : "TERM";
+      // `kill -s NAME -- -pid` is the group-kill spelling dash accepts. Without setsid there is
+      // no dedicated group, so take down the wrapper's children before the wrapper itself.
+      const target = hasGroup
+        ? `kill -s ${name} -- -${pid} 2>/dev/null || kill -s ${name} ${pid} 2>/dev/null`
+        : `pkill -${name} -P ${pid} 2>/dev/null; kill -s ${name} ${pid} 2>/dev/null`;
+      await exec(`${target}; true`);
+    },
+  };
+}
+
+function previewUrl(instanceUrl: string, port: number): string {
+  const url = new URL(instanceUrl);
+  const [label, ...rest] = url.hostname.split(".");
+  return `https://${label}-${port}.${rest.join(".")}`;
+}
+
+function withEnv(
+  createOptions: { env: Readonly<Record<string, string>> },
+  runOptions: RunOptions,
+): RunOptions {
+  return { ...runOptions, env: { ...createOptions.env, ...runOptions.env } };
+}
+
+function scopedCommand(
+  input: CommandInput,
+  options: RunOptions,
+  virtualCwd: string,
+  remoteCwd: string,
+): string {
+  const environment = Object.entries(options.env ?? {}).map(([key, value]) =>
+    shellQuote(`${key}=${value}`),
+  );
+  const shell = `sh -c ${shellQuote(commandString(input))}`;
+  const timed = options.timeout
+    ? `timeout ${Math.max(1, Math.ceil(options.timeout / 1_000))}s ${shell}`
+    : shell;
+  const cwd = replacePathPrefix(options.cwd ?? virtualCwd, virtualCwd, remoteCwd);
+  return `cd ${shellQuote(cwd)} && ${
+    environment.length ? `env ${environment.join(" ")} ` : ""
+  }${timed}`;
+}
+
+function replacePathPrefix(path: string, from: string, to: string): string {
+  if (path === from) return to;
+  if (path.startsWith(`${from}/`)) return `${to}${path.slice(from.length)}`;
+  return path;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function validatePort(port: number): void {
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new SandboxError({
+      code: "invalid_input",
+      provider: "agent37",
+      operation: "ports.expose",
+      message: `Invalid port: ${port}`,
+    });
+  }
+}
+
+function assertNotAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw signal.reason ?? new DOMException("Aborted", "AbortError");
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal?.reason ?? new DOMException("Aborted", "AbortError"));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/packages/sdk/src/providers/capabilities.ts
+++ b/packages/sdk/src/providers/capabilities.ts
@@ -80,6 +80,22 @@ export const vercelCapabilities = defineCapabilities({
   "network.policy": "native",
 });
 
+export const agent37Capabilities = defineCapabilities({
+  "files.read": "full",
+  "files.write": "full",
+  "files.list": "full",
+  "files.remove": "full",
+  "process.run": "separate-streams",
+  "process.stream": "combined-stream",
+  "process.background": "full",
+  "process.cancel": "full",
+  "ports.expose": "authenticated",
+  "ports.authenticatedRequest": "authenticated",
+  "sandbox.resume": "persistent",
+  "filesystem.persistent": "persistent",
+  "image.custom": "template",
+});
+
 export const upstashCapabilities = defineCapabilities({
   "files.read": "full",
   "files.write": "full",

--- a/packages/sdk/tests/live/agent37.test.ts
+++ b/packages/sdk/tests/live/agent37.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test";
+import { createSandbox } from "../../src";
+import { agent37 } from "../../src/providers/agent37";
+
+test.skipIf(!process.env.AGENT37_API_KEY)(
+  "Agent37 live conformance smoke test",
+  async () => {
+    const sandbox = await createSandbox({
+      provider: agent37({ template: "agent37-hermes-small" }),
+      timeout: 240_000,
+    });
+    try {
+      expect((await sandbox.run("printf live-agent37")).stdout).toContain("live-agent37");
+      expect(await sandbox.run("printf out; printf err >&2; exit 7")).toMatchObject({
+        stdout: "out",
+        stderr: "err",
+        exitCode: 7,
+        success: false,
+      });
+      await expect(sandbox.run("sleep 2", { timeout: 100 })).rejects.toMatchObject({
+        code: "timeout",
+        provider: "agent37",
+      });
+
+      await sandbox.files.write("live.txt", "live-file");
+      expect(await sandbox.files.text("live.txt")).toBe("live-file");
+
+      const process = await sandbox.processes.start("printf started");
+      expect(await process.wait()).toEqual({ exitCode: 0 });
+      let output = "";
+      for await (const event of process.output()) {
+        output +=
+          typeof event.data === "string" ? event.data : new TextDecoder().decode(event.data);
+      }
+      expect(output).toContain("started");
+    } finally {
+      await sandbox.stop();
+    }
+  },
+  300_000,
+);

--- a/packages/sdk/tests/providers/agent37.test.ts
+++ b/packages/sdk/tests/providers/agent37.test.ts
@@ -1,0 +1,169 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { createSandbox } from "../../src";
+import { agent37 } from "../../src/providers/agent37";
+
+const WORKSPACE = "/home/user/.agent37-gateway/workspace";
+const files = new Map<string, Uint8Array<ArrayBuffer>>();
+const requests: string[] = [];
+const commands: string[] = [];
+let sleeping = false;
+
+const instance = {
+  id: "agent37-test",
+  status: "running",
+  template: "agent37-hermes",
+  resources: { cpu: 2, memory: 4, disk: 6 },
+  url: "https://agent37-test.agent37.app",
+  public_ports: [],
+  name: null,
+  user: null,
+  metadata: null,
+  auto_sleep: false,
+  idle_timeout_seconds: 300,
+  created: 1781222400,
+};
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function runCommand(command: string) {
+  commands.push(command);
+  if (command.includes("sleep 2") && command.includes("timeout 1s "))
+    return { exit_code: 124, stdout: "", stderr: "", truncated: false };
+  if (command.includes("exit 7"))
+    return { exit_code: 7, stdout: "out", stderr: "err", truncated: false };
+  if (command.includes("node") && command.includes("--version"))
+    return { exit_code: 0, stdout: "v24.0.0", stderr: "", truncated: false };
+  return { exit_code: 0, stdout: "", stderr: "", truncated: false };
+}
+
+async function fakeFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const url = new URL(input instanceof Request ? input.url : input);
+  const method = (init?.method ?? "GET").toUpperCase();
+  const headers = new Headers(init?.headers);
+  requests.push(`${method} ${url.host}${url.pathname}`);
+  if (url.host === "api.agent37.com") {
+    if (headers.get("authorization") !== "Bearer sk_live_test")
+      return json({ error: { code: "invalid_api_key", message: "Missing key" } }, 401);
+    if (method === "POST" && url.pathname === "/v1/instances") return json(instance);
+    if (method === "POST" && url.pathname === `/v1/instances/${instance.id}/exec`) {
+      if (sleeping)
+        return json({ error: { code: "invalid_request", message: "Instance is sleeping" } }, 400);
+      return json(runCommand((JSON.parse(init?.body as string) as { command: string }).command));
+    }
+    if (method === "DELETE" && url.pathname === `/v1/instances/${instance.id}`)
+      return json({ ok: true });
+  }
+  if (url.host === "agent37-test.agent37.app") {
+    if (!headers.has("x-agent37-key")) return json({ error: "invalid_api_key" }, 401);
+    const path = url.searchParams.get("path");
+    if (url.pathname === "/v1/health") {
+      sleeping = false;
+      return json({ ok: true });
+    }
+    if (url.pathname === "/v1/files" && method === "GET" && !path)
+      return json({ path: WORKSPACE, parentPath: null, entries: [], truncated: false });
+    if (url.pathname === "/v1/files/content" && method === "PUT") {
+      files.set(path!, new Uint8Array(init?.body as Uint8Array));
+      return json({ name: path!.split("/").at(-1), path, type: "file" });
+    }
+    if (url.pathname === "/v1/files/content" && method === "GET") {
+      const content = files.get(path!);
+      return content ? new Response(content) : json({ error: "file_not_found" }, 404);
+    }
+  }
+  if (url.host === "agent37-test-8080.agent37.app")
+    return json({ authenticated: new Headers(init?.headers).has("x-agent37-key") });
+  return json({ error: "not_found" }, 404);
+}
+
+const originalFetch = globalThis.fetch;
+beforeAll(() => {
+  globalThis.fetch = fakeFetch as typeof fetch;
+});
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("Agent37 adapter", () => {
+  test("maps REST operations onto the instance workspace", async () => {
+    const sandbox = await createSandbox({ provider: agent37({ apiKey: "sk_live_test" }) });
+    await sandbox.files.write("file.txt", "value");
+    expect(await sandbox.files.text("file.txt")).toBe("value");
+    expect(files.has(`${WORKSPACE}/file.txt`)).toBe(true);
+    expect(await sandbox.run({ command: "node", args: ["--version"] })).toMatchObject({
+      stdout: "v24.0.0",
+      success: true,
+    });
+    expect(await sandbox.run("printf out; printf err >&2; exit 7")).toMatchObject({
+      stdout: "out",
+      stderr: "err",
+      exitCode: 7,
+      success: false,
+    });
+    await sandbox.run("true", { env: { FOO: "bar" }, cwd: "sub" });
+    expect(commands.at(-1)).toBe(`cd '${WORKSPACE}/sub' && env 'FOO=bar' sh -c 'true'`);
+    const port = await sandbox.ports.expose(8080);
+    expect(port).toMatchObject({
+      port: 8080,
+      url: "https://agent37-test-8080.agent37.app",
+      public: false,
+      authenticated: true,
+    });
+    expect(await (await port.request!("/")).json()).toEqual({ authenticated: true });
+    await sandbox.stop();
+    expect(sandbox.raw.instance.id).toBe("agent37-test");
+    expect(requests).toContain(`DELETE api.agent37.com/v1/instances/${instance.id}`);
+  });
+
+  test("normalizes shell timeout exit 124", async () => {
+    const sandbox = await createSandbox({ provider: agent37({ apiKey: "sk_live_test" }) });
+    await expect(sandbox.run("sleep 2", { timeout: 20 })).rejects.toMatchObject({
+      code: "timeout",
+      provider: "agent37",
+      operation: "process.run",
+    });
+    expect(commands.at(-1)).toContain("timeout 1s sh -c 'sleep 2'");
+    await sandbox.stop();
+  });
+
+  test("wakes a sleeping instance before running commands", async () => {
+    const sandbox = await createSandbox({ provider: agent37({ apiKey: "sk_live_test" }) });
+    sleeping = true;
+    expect(await sandbox.run({ command: "node", args: ["--version"] })).toMatchObject({
+      stdout: "v24.0.0",
+      success: true,
+    });
+    expect(sleeping).toBe(false);
+    expect(requests.at(-2)).toBe("GET agent37-test.agent37.app/v1/health");
+    await sandbox.stop();
+  });
+
+  test("requires an API key", async () => {
+    const saved = process.env.AGENT37_API_KEY;
+    delete process.env.AGENT37_API_KEY;
+    try {
+      await expect(createSandbox({ provider: agent37() })).rejects.toMatchObject({
+        code: "authentication",
+        provider: "agent37",
+        operation: "sandbox.create",
+      });
+    } finally {
+      if (saved !== undefined) process.env.AGENT37_API_KEY = saved;
+    }
+  });
+
+  test("reports unsupported snapshots", async () => {
+    const sandbox = await createSandbox({ provider: agent37({ apiKey: "sk_live_test" }) });
+    await expect(sandbox.snapshots.create()).rejects.toMatchObject({
+      code: "unsupported",
+      provider: "agent37",
+    });
+    expect(sandbox.capabilities["snapshot.create"]).toBe(false);
+    await sandbox.stop();
+  });
+});

--- a/packages/sdk/tests/types/provider-contracts.typecheck.ts
+++ b/packages/sdk/tests/types/provider-contracts.typecheck.ts
@@ -9,6 +9,7 @@ import { e2b } from "../../src/providers/e2b";
 import { local, type LocalSandbox } from "../../src/providers/local";
 import { vercel } from "../../src/providers/vercel";
 import { upstash } from "../../src/providers/upstash";
+import { agent37, type Agent37Sandbox } from "../../src/providers/agent37";
 
 const localContract: SandboxProvider<LocalSandbox> = local();
 const agentosContract: SandboxProvider<AgentOsSandbox> = agentos();
@@ -16,6 +17,7 @@ const e2bContract: SandboxProvider<E2BNative> = e2b();
 const daytonaContract: SandboxProvider<DaytonaNative> = daytona();
 const vercelContract: SandboxProvider<VercelNative> = vercel();
 const upstashContract: SandboxProvider<UpstashNative> = upstash();
+const agent37Contract: SandboxProvider<Agent37Sandbox> = agent37();
 void [
   localContract,
   agentosContract,
@@ -23,6 +25,7 @@ void [
   daytonaContract,
   vercelContract,
   upstashContract,
+  agent37Contract,
 ];
 
 // @ts-expect-error Explicit access-token authentication requires the complete credential triple.

--- a/packages/sdk/tests/types/raw.typecheck.ts
+++ b/packages/sdk/tests/types/raw.typecheck.ts
@@ -9,6 +9,7 @@ import { e2b } from "../../src/providers/e2b";
 import { local, type LocalSandbox } from "../../src/providers/local";
 import { vercel } from "../../src/providers/vercel";
 import { upstash } from "../../src/providers/upstash";
+import { agent37, type Agent37Sandbox } from "../../src/providers/agent37";
 
 async function rawTypes() {
   const localSandbox: LocalSandbox = (await createSandbox({ provider: local() })).raw;
@@ -17,7 +18,16 @@ async function rawTypes() {
   const daytonaSandbox: DaytonaNative = (await createSandbox({ provider: daytona() })).raw;
   const vercelSandbox: VercelNative = (await createSandbox({ provider: vercel() })).raw;
   const upstashSandbox: UpstashNative = (await createSandbox({ provider: upstash() })).raw;
-  void [localSandbox, agentosSandbox, e2bSandbox, daytonaSandbox, vercelSandbox, upstashSandbox];
+  const agent37Sandbox: Agent37Sandbox = (await createSandbox({ provider: agent37() })).raw;
+  void [
+    localSandbox,
+    agentosSandbox,
+    e2bSandbox,
+    daytonaSandbox,
+    vercelSandbox,
+    upstashSandbox,
+    agent37Sandbox,
+  ];
 }
 
 async function disposableSandbox() {

--- a/packages/sdk/tsdown.config.ts
+++ b/packages/sdk/tsdown.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     "src/providers/daytona/index.ts",
     "src/providers/vercel/index.ts",
     "src/providers/upstash/index.ts",
+    "src/providers/agent37/index.ts",
     "src/ai/index.ts",
     "src/ai/harness.ts",
     "src/eve/index.ts",

--- a/skills/sandbox-sdk/SKILL.md
+++ b/skills/sandbox-sdk/SKILL.md
@@ -5,7 +5,7 @@ description: Use when implementing isolated code execution with @opencoredev/san
 
 # Sandbox SDK
 
-Use one normalized TypeScript interface across Local, E2B, Daytona, Vercel Sandbox, and Upstash Box.
+Use one normalized TypeScript interface across Local, E2B, Daytona, Vercel Sandbox, Upstash Box, and Agent37.
 
 ## Start here
 


### PR DESCRIPTION
Adds [Agent37](https://www.agent37.com/docs) as a provider: `agent37()` runs sandboxes on persistent Agent37 instances, driven entirely over the platform's REST APIs with **no SDK dependency** (plain `fetch`), so there is no new package or peer dependency.

## How it maps

| SDK surface | Agent37 |
| --- | --- |
| `create()` | `POST /v1/instances` (template/resources/name/auto-sleep options), then polls the in-instance gateway `/v1/health` until healthy |
| `run()` | `POST /v1/instances/{id}/exec` — separate stdout/stderr and exit codes; user timeouts via a `timeout Ns` wrapper (exit 124 → `timeout` error); execs killed by the platform's 280s cap are surfaced as `timeout` with a pointer to `processes.start()` |
| `processes.start()` | The platform's own recommended background pattern: `setsid`/nohup launcher writing to output + exit files, polled over exec; combined output stream, TERM/KILL cancellation (dash-safe `kill -s` group kill, `pkill -P` fallback when `setsid` is absent), stdin unsupported |
| `files.*` | Gateway file endpoints (`/v1/files`, `/v1/files/content`, `/v1/files/dir`); the SDK's virtual cwd maps onto the instance's real workspace path (same scheme as the Upstash adapter) |
| `ports.expose()` | Derivable preview URLs (`https://{id}-{port}.agent37.app`), key-authenticated with the key kept inside `request()`; `public: true` switches to permanent unauthenticated public-port URLs |
| Managed sessions | stop/resume/destroy map to instance stop/start/delete; the instance disk persists across stop/resume (`filesystem.persistent`/`sandbox.resume`: `persistent`) |
| Snapshots | Unsupported (no snapshot API; persistence covers stop/resume) |

Notable behaviors:
- Exec never wakes a sleeping (auto-sleep) instance and idle time is only measured on instance-URL traffic, so exec-backed operations detect the `invalid_request` refusal, wake the instance with a gateway probe, and retry once.
- Hosting/gateway/transport error catalogs are mapped onto normalized `SandboxError` codes with the vendor's retryable codes marked.
- `sandbox.raw` exposes the instance record plus `hosting()`, `gateway()`, `exec()`, and lifecycle escape hatches.

## Also included

- Unit tests (mock `fetch` covering cwd mapping, stream separation, timeout, wake-retry, auth, ports, delete-on-stop), typecheck contract tests, and a live smoke test (`AGENT37_API_KEY`-gated, skips cleanly)
- Docs: provider page, providers index, compatibility notes, package exports, Mastra table, icon; README/SKILL/CHANGELOG/example
- CI: `agent37` added to the live-compatibility matrix (needs an `AGENT37_API_KEY` secret)

## Verification

`tsc --noEmit`, `oxlint`, `oxfmt --check`, `tsdown` build, and `bun test` all pass; the only suite failures are the 3 Daytona live tests that fail identically on `main` (cross-file mock pollution, unrelated). Shell plumbing for the background-process launcher/probe/kill was exercised against `sh`, `dash`, and `bash` locally.

The branch also went through a multi-agent adversarial review (5 lenses, findings independently double-verified); all 15 confirmed findings were fixed, including a Bun-specific `Response.body.cancel()` incompatibility, dash's rejection of `kill -- -pid`, and doc claims that overstated arbitrary-image support (custom templates must build on a gateway-bearing base image).

https://claude.ai/code/session_01A2fAdfNdc2iwY4FjAbtz1X